### PR TITLE
Generate weekly report from sent emails and schedule Friday runs

### DIFF
--- a/gui/components/top_panel.py
+++ b/gui/components/top_panel.py
@@ -20,6 +20,7 @@ from services.email_service import EmailService
 from services.scheduler_service import SchedulerService
 from services.search_service import SearchService
 from services.progress_service import ProgressService
+from services.weekly_report_service import WeeklyReportService
 
 
 class TopPanel:
@@ -38,6 +39,7 @@ class TopPanel:
         self.profile_manager = ProfileManager()
         self.report_service = ReportService()
         self.email_service = EmailService()
+        self.weekly_report_service = WeeklyReportService()
 
         # Inicializar el servicio de progreso
         self.progress_service = ProgressService(
@@ -94,27 +96,34 @@ class TopPanel:
         )
         self.generate_report_btn.grid(row=0, column=0, padx=(0, 5))
 
+        self.weekly_report_btn = ttk.Button(
+            self.button_frame,
+            text="Generar Reporte Semanal",
+            command=self._generate_weekly_report_async
+        )
+        self.weekly_report_btn.grid(row=0, column=1, padx=(0, 5))
+
         # Botón de programación
         self.schedule_btn = ttk.Button(
             self.button_frame,
             text="Programar Envíos",
             command=self._open_scheduler_modal_safe
         )
-        self.schedule_btn.grid(row=0, column=1, padx=(0, 5))
+        self.schedule_btn.grid(row=0, column=2, padx=(0, 5))
 
         self.search_all_btn = ttk.Button(
             self.button_frame,
             text="Buscar Todos",
             command=self._run_global_search_async
         )
-        self.search_all_btn.grid(row=0, column=2, padx=(0, 5))
+        self.search_all_btn.grid(row=0, column=3, padx=(0, 5))
 
         self.new_btn = ttk.Button(
             self.button_frame,
             text="Nuevo Perfil",
             command=self._open_new_profile_modal
         )
-        self.new_btn.grid(row=0, column=3)
+        self.new_btn.grid(row=0, column=4)
 
         # Frame para el grid con scrollbar
         self.grid_frame = ttk.Frame(self.parent_frame)
@@ -553,6 +562,44 @@ class TopPanel:
         thread = threading.Thread(target=report_thread, daemon=True)
         thread.start()
 
+    def _generate_weekly_report_async(self):
+        """Genera un reporte semanal combinando adjuntos enviados."""
+        if self.is_searching or self.is_generating_report:
+            messagebox.showwarning(
+                "Operación en Progreso",
+                "Ya hay una operación en curso. Espera a que termine.",
+            )
+            return
+
+        self.is_generating_report = True
+        self._set_buttons_state("disabled")
+
+        self.progress_service.start_operation(
+            "Generación de Reporte Semanal",
+            1,
+            can_cancel=False,
+        )
+
+        def report_thread():
+            try:
+                report_path = self.weekly_report_service.generate_weekly_report()
+                if report_path:
+                    self.progress_service.complete_operation(
+                        f"Reporte semanal generado: {report_path}"
+                    )
+                else:
+                    self.progress_service.error_operation(
+                        "No se encontraron correos semanales con adjuntos."
+                    )
+            except Exception as e:
+                self.progress_service.error_operation(
+                    f"Error al generar reporte semanal: {e}"
+                )
+            finally:
+                self.parent_frame.after(0, lambda: self._finish_report_operation())
+
+        threading.Thread(target=report_thread, daemon=True).start()
+
     def _perform_report_generation_threaded(self, profiles):
         """Ejecuta la generación de reporte en un hilo separado."""
         try:
@@ -658,7 +705,13 @@ class TopPanel:
 
     def _set_buttons_state(self, state):
         """Cambia el estado de todos los botones principales."""
-        buttons = [self.generate_report_btn, self.schedule_btn, self.search_all_btn, self.new_btn]
+        buttons = [
+            self.generate_report_btn,
+            self.weekly_report_btn,
+            self.schedule_btn,
+            self.search_all_btn,
+            self.new_btn,
+        ]
         for btn in buttons:
             btn.config(state=state)
 

--- a/services/report_service.py
+++ b/services/report_service.py
@@ -446,10 +446,39 @@ class ReportService:
                     )
 
     def get_reports_directory(self):
-        """
-        Retorna el directorio donde se guardan los reportes.
+        """Retorna el directorio donde se guardan los reportes."""
+        return str(self.reports_dir)
+
+    def merge_excels(self, excel_paths, output_name="reporte_semanal.xlsx"):
+        """Combina múltiples archivos Excel en un solo libro.
+
+        Args:
+            excel_paths (list): Lista de rutas de archivos Excel.
+            output_name (str): Nombre del archivo combinado.
 
         Returns:
-            str: Ruta del directorio de reportes
+            str: Ruta del archivo resultante.
         """
-        return str(self.reports_dir)
+        if openpyxl is None:
+            raise Exception("openpyxl no está instalado. Ejecute: pip install openpyxl")
+
+        workbook = openpyxl.Workbook()
+        sheet = workbook.active
+        sheet.title = "Reporte Semanal"
+
+        headers_written = False
+        for path in excel_paths:
+            wb = openpyxl.load_workbook(path)
+            ws = wb.active
+            rows = list(ws.iter_rows(values_only=True))
+            if not rows:
+                continue
+            if not headers_written:
+                sheet.append(rows[0])
+                headers_written = True
+            for row in rows[1:]:
+                sheet.append(row)
+
+        output_path = self.reports_dir / output_name
+        workbook.save(output_path)
+        return str(output_path)

--- a/services/scheduler_service.py
+++ b/services/scheduler_service.py
@@ -138,27 +138,18 @@ class SchedulerService:
                 current_time = now.strftime("%H:%M")
                 scheduled_time = config.get("time", "08:00")
 
-                # Mapeo de días de la semana (0 = lunes en Python)
-                day_mapping = {
-                    0: "monday", 1: "tuesday", 2: "wednesday", 3: "thursday",
-                    4: "friday", 5: "saturday", 6: "sunday"
-                }
-
-                current_day = day_mapping.get(now.weekday())
-                days_config = config.get("days", {})
-
                 # Calcular próxima ejecución para logs
                 self._calculate_next_execution(config, now)
 
-                # Verificar si hoy es un día programado y si es la hora configurada
+                # Ejecutar cada viernes a la hora configurada
                 should_execute = (
-                        days_config.get(current_day, False) and
+                        now.weekday() == 4 and
                         current_time == scheduled_time and
                         now.date() != last_execution_date.date()
                 )
 
                 if should_execute:
-                    self._log(f"⏰ Ejecutando reporte programado: {current_day} {scheduled_time}")
+                    self._log(f"⏰ Ejecutando reporte programado: viernes {scheduled_time}")
 
                     # Ejecutar reporte de manera thread-safe
                     success = self._execute_scheduled_report()
@@ -197,35 +188,20 @@ class SchedulerService:
     def _calculate_next_execution(self, config, current_time):
         """Calcula y guarda la próxima ejecución programada."""
         try:
-            days_config = config.get("days", {})
             scheduled_time = config.get("time", "08:00")
+            hour, minute = map(int, scheduled_time.split(":"))
 
-            # Encontrar el próximo día programado
-            current_weekday = current_time.weekday()
+            # Calcular próximo viernes
+            days_ahead = (4 - current_time.weekday()) % 7
+            next_date = current_time.date() + timedelta(days=days_ahead)
+            scheduled_datetime = datetime.combine(next_date, datetime.min.time()).replace(
+                hour=hour, minute=minute
+            )
 
-            for i in range(7):  # Buscar en los próximos 7 días
-                check_day = (current_weekday + i) % 7
-                day_name = ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"][check_day]
+            if scheduled_datetime <= current_time:
+                scheduled_datetime += timedelta(days=7)
 
-                if days_config.get(day_name, False):
-                    # Calcular fecha y hora
-                    days_ahead = i
-                    hour, minute = map(int, scheduled_time.split(":"))
-
-                    # Si es hoy pero ya pasó la hora, buscar el siguiente día programado
-                    if i == 0:
-                        scheduled_datetime = current_time.replace(hour=hour, minute=minute, second=0, microsecond=0)
-                        if scheduled_datetime <= current_time:
-                            continue  # Ya pasó la hora de hoy, buscar siguiente día
-                    else:
-                        next_date = current_time.date() + timedelta(days=days_ahead)
-                        scheduled_datetime = datetime.combine(next_date,
-                                                              datetime.min.time().replace(hour=hour, minute=minute))
-
-                    self.next_execution = scheduled_datetime
-                    break
-            else:
-                self.next_execution = None
+            self.next_execution = scheduled_datetime
 
         except Exception as e:
             self._log(f"⚠️ Error calculando próxima ejecución: {e}")
@@ -250,6 +226,11 @@ class SchedulerService:
             except Exception as e:
                 self._log(f"💥 Error al ejecutar reporte programado: {e}")
                 return False
+
+    def run_manual_report(self):
+        """Permite ejecutar el generador de reportes manualmente."""
+        self._log("🖐️ Ejecución manual del reporte solicitada")
+        return self._execute_scheduled_report()
 
     def _load_config(self):
         """Carga configuración de programación de manera segura."""

--- a/services/weekly_report_service.py
+++ b/services/weekly_report_service.py
@@ -1,0 +1,69 @@
+"""weekly_report_service.py
+Servicio para generar un reporte semanal a partir de correos enviados.
+Recorre el directorio 'enviados/' buscando correos con un asunto
+específico y extrae los adjuntos en formato Excel para combinarlos
+en un solo reporte utilizando ReportService.
+"""
+
+from pathlib import Path
+from datetime import datetime
+import email
+
+try:
+    import openpyxl
+except ImportError:  # pragma: no cover - dependencia opcional
+    openpyxl = None
+
+from services.report_service import ReportService
+
+
+class WeeklyReportService:
+    """Servicio que construye reportes semanales a partir de correos enviados."""
+
+    def __init__(self, sent_dir: str = "enviados", subject_keyword: str = "Reporte Semanal"):
+        self.sent_dir = Path(sent_dir)
+        self.subject_keyword = subject_keyword
+        self.report_service = ReportService()
+
+    def _find_weekly_attachments(self):
+        """Busca correos con el asunto semanal y extrae adjuntos Excel."""
+        attachments = []
+        if not self.sent_dir.exists():
+            return attachments
+
+        for eml_file in self.sent_dir.glob("*.eml"):
+            try:
+                with open(eml_file, "r", encoding="utf-8", errors="ignore") as fp:
+                    msg = email.message_from_file(fp)
+                subject = msg.get("Subject", "")
+                if self.subject_keyword.lower() not in subject.lower():
+                    continue
+                for part in msg.walk():
+                    if part.get_content_disposition() == "attachment":
+                        filename = part.get_filename()
+                        if filename and filename.lower().endswith((".xls", ".xlsx")):
+                            attachment_path = self.sent_dir / filename
+                            if not attachment_path.exists():
+                                with open(attachment_path, "wb") as out:
+                                    out.write(part.get_payload(decode=True))
+                            attachments.append(attachment_path)
+            except Exception:
+                continue
+        return attachments
+
+    def generate_weekly_report(self):
+        """Genera un único reporte Excel a partir de adjuntos semanales.
+
+        Returns:
+            str | None: Ruta del reporte generado o None si no se encontraron adjuntos.
+        """
+        if openpyxl is None:
+            raise Exception("openpyxl no está instalado. Ejecute: pip install openpyxl")
+
+        excel_files = self._find_weekly_attachments()
+        if not excel_files:
+            return None
+
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        output_name = f"reporte_semanal_{timestamp}.xlsx"
+        return self.report_service.merge_excels(excel_files, output_name)


### PR DESCRIPTION
## Summary
- Add WeeklyReportService to scan `enviados/` and assemble weekly Excel reports
- Merge multiple Excel attachments into a single file via ReportService
- Provide UI button and async flow for manual weekly report generation
- Schedule report generation every Friday and expose manual trigger in SchedulerService

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0a67934588325b973e13101c0c81a