### PR TITLE
Refactor scheduler and search logic

### DIFF
--- a/gui/components/scheduler_modal.py
+++ b/gui/components/scheduler_modal.py
@@ -1,433 +1,539 @@
-# gui/components/scheduler_modal.py
-"""
-Modal para configurar programación de envío automático de reportes.
-Implementa un diseño horizontal optimizado con dos columnas principales:
-configuración diaria a la izquierda y semanal a la derecha.
-"""
+"""Modal unificado para configurar programación automática de reportes."""
 
+import os
+import json
 import tkinter as tk
 from tkinter import ttk, messagebox
-import json
-import os
-from pathlib import Path
 from datetime import datetime
+from pathlib import Path
+from typing import Dict, Optional
 
 
 class SchedulerModal:
-    """Modal optimizado con diseño horizontal para configuración de reportes diarios y semanales."""
+    """Modal que centraliza la configuración diaria, semanal y mensual."""
 
-    def __init__(self, parent, bottom_panel=None):
-        """
-        Inicializa el modal de programación con diseño horizontal.
+    DAY_NAMES = {
+        "monday": "Lunes",
+        "tuesday": "Martes",
+        "wednesday": "Miércoles",
+        "thursday": "Jueves",
+        "friday": "Viernes",
+        "saturday": "Sábado",
+        "sunday": "Domingo",
+    }
 
-        Args:
-            parent: Widget padre
-            bottom_panel: Referencia al panel para registrar logs
-        """
+    def __init__(self, parent, bottom_panel=None, on_close=None):
         self.parent = parent
         self.bottom_panel = bottom_panel
+        self.on_close = on_close
+
         self.config_file = Path("config") / "scheduler_config.json"
+        os.makedirs(self.config_file.parent, exist_ok=True)
 
-        # Crear directorio de configuración
-        os.makedirs(Path("config"), exist_ok=True)
-
-        # Crear ventana modal optimizada para layout horizontal
-        self.modal = tk.Toplevel(parent)
-        self.modal.title("Programación de Reportes")
-        self.modal.geometry("800x600")  # Más ancho y menos alto para layout horizontal
-        self.modal.resizable(False, False)
-        self.modal.transient(parent)
-        self.modal.grab_set()
-
-        # Variables para días de la semana (reportes diarios)
-        self.days = {
-            "monday": tk.BooleanVar(value=False),
-            "tuesday": tk.BooleanVar(value=False),
-            "wednesday": tk.BooleanVar(value=False),
-            "thursday": tk.BooleanVar(value=False),
-            "friday": tk.BooleanVar(value=False),
-            "saturday": tk.BooleanVar(value=False),
-            "sunday": tk.BooleanVar(value=False)
-        }
-
-        # Variables para hora (reportes diarios)
+        # Variables compartidas
+        self.days = {day: tk.BooleanVar(value=False) for day in self.DAY_NAMES}
         self.hour = tk.StringVar(value="08")
         self.minute = tk.StringVar(value="00")
-
-        # Variable para habilitar/deshabilitar programación diaria
         self.enabled = tk.BooleanVar(value=False)
 
-        # Variable para habilitar/deshabilitar programación semanal
         self.weekly_enabled = tk.BooleanVar(value=False)
-
-        # Variable para día de la semana del reporte semanal
         self.weekly_day = tk.StringVar(value="friday")
-
-        # Variables para hora del reporte semanal
         self.weekly_hour = tk.StringVar(value="16")
         self.weekly_minute = tk.StringVar(value="00")
 
-        # Centrar ventana
-        self._center_window()
+        self.monthly_enabled = tk.BooleanVar(value=False)
+        self.monthly_day_type = tk.StringVar(value="specific")
+        self.monthly_day = tk.StringVar(value="1")
+        self.monthly_hour = tk.StringVar(value="09")
+        self.monthly_minute = tk.StringVar(value="00")
 
-        # Cargar configuración existente
+        # Widgets que se activan/desactivan según switches
+        self.daily_controls = []
+        self.weekly_controls = []
+        self.monthly_controls = []
+
+        # Configuración inicial desde archivo
         self._load_config()
 
-        # Configurar widgets con layout horizontal
-        self._setup_widgets()
+        # Construcción de UI
+        self.modal = tk.Toplevel(parent)
+        self.modal.title("Programación de Reportes")
+        self.modal.geometry("820x640")
+        self.modal.resizable(False, False)
+        self.modal.transient(parent)
+        self.modal.grab_set()
+        self.modal.protocol("WM_DELETE_WINDOW", self._handle_close)
 
+        self._setup_widgets()
+        self._toggle_daily_scheduler()
+        self._toggle_weekly_scheduler()
+        self._toggle_monthly_scheduler()
+        self._update_day_selection()
+        self._center_window()
+
+    # ------------------------------------------------------------------
+    # Construcción de widgets
+    # ------------------------------------------------------------------
     def _setup_widgets(self):
-        """Configura la interfaz del modal con layout horizontal."""
-        # Frame principal
         main_frame = ttk.Frame(self.modal, padding="25 25 25 25")
         main_frame.pack(fill=tk.BOTH, expand=True)
 
-        # Configurar grid principal con dos columnas de igual ancho
         main_frame.columnconfigure(0, weight=1)
         main_frame.columnconfigure(1, weight=1)
 
-        # Título general (ocupa ambas columnas)
         title_label = ttk.Label(
             main_frame,
-            text="⏰ Programación de Reportes",
-            font=("Arial", 14, "bold")
+            text="⏰ Programación de Reportes Automáticos",
+            font=("Arial", 14, "bold"),
         )
         title_label.grid(row=0, column=0, columnspan=2, pady=(0, 20))
 
-        # ==== SECCIÓN DE REPORTES DIARIOS (COLUMNA IZQUIERDA) ====
+        # ----- Configuración diaria -----
         daily_frame = ttk.LabelFrame(
             main_frame,
-            text="Configuración de Reportes Diarios",
-            padding="15 15 15 15"
+            text="Reportes Diarios",
+            padding="15 15 15 15",
         )
-        daily_frame.grid(row=1, column=0, sticky="nsew", padx=(0, 10))
+        daily_frame.grid(row=1, column=0, sticky="nsew", padx=(0, 12))
 
-        # Switch para activar/desactivar programación diaria
-        enable_switch = ttk.Checkbutton(
+        enable_daily = ttk.Checkbutton(
             daily_frame,
-            text="Activar envío automático de reportes diarios",
+            text="Activar envío automático diario",
             variable=self.enabled,
-            command=self._toggle_daily_scheduler
+            command=self._toggle_daily_scheduler,
         )
-        enable_switch.grid(row=0, column=0, columnspan=2, sticky="w", pady=(0, 10))
+        enable_daily.grid(row=0, column=0, columnspan=2, sticky="w", pady=(0, 10))
 
-        # Frame para días de la semana (optimizado para layout vertical)
-        days_frame = ttk.LabelFrame(
-            daily_frame,
-            text="Días de envío",
-            padding="10 10 10 10"
-        )
-        days_frame.grid(row=1, column=0, columnspan=2, sticky="nsew", pady=(0, 15))
+        days_frame = ttk.LabelFrame(daily_frame, text="Días de ejecución", padding="10 10 10 10")
+        days_frame.grid(row=1, column=0, columnspan=2, sticky="nsew", pady=(0, 10))
 
-        # Mapeo de días con nombres en español
-        day_names = {
-            "monday": "Lunes",
-            "tuesday": "Martes",
-            "wednesday": "Miércoles",
-            "thursday": "Jueves",
-            "friday": "Viernes",
-            "saturday": "Sábado",
-            "sunday": "Domingo"
-        }
+        for index, (day_key, day_name) in enumerate(self.DAY_NAMES.items()):
+            day_cb = ttk.Checkbutton(days_frame, text=day_name, variable=self.days[day_key])
+            day_cb.grid(row=index // 2, column=index % 2, sticky="w", padx=5, pady=2)
+            self.daily_controls.append(day_cb)
 
-        # Crear los checkboxes de días en una columna
-        for i, (day_key, day_name) in enumerate(day_names.items()):
-            day_check = ttk.Checkbutton(
-                days_frame,
-                text=day_name,
-                variable=self.days[day_key]
-            )
-            day_check.grid(row=i, column=0, sticky="w", padx=10, pady=2)
+        time_frame = ttk.LabelFrame(daily_frame, text="Hora diaria", padding="10 10 10 10")
+        time_frame.grid(row=2, column=0, columnspan=2, sticky="nsew")
 
-        # Frame para hora de envío diario
-        daily_time_frame = ttk.LabelFrame(
-            daily_frame,
-            text="Hora de envío",
-            padding="10 10 10 10"
-        )
-        daily_time_frame.grid(row=2, column=0, columnspan=2, sticky="nsew", pady=(0, 10))
-
-        # Selector de hora para reportes diarios
         hour_values = [f"{i:02d}" for i in range(24)]
+        minute_values = [f"{i:02d}" for i in range(0, 60, 5)]
+
         hour_combo = ttk.Combobox(
-            daily_time_frame,
+            time_frame,
             textvariable=self.hour,
             values=hour_values,
             width=5,
-            state="readonly"
+            state="readonly",
         )
-        hour_combo.grid(row=0, column=0, sticky="e", padx=(0, 5))
-
-        ttk.Label(daily_time_frame, text=":").grid(row=0, column=1)
-
-        minute_values = [f"{i:02d}" for i in range(0, 60, 5)]
+        hour_combo.grid(row=0, column=0, padx=(0, 5))
         minute_combo = ttk.Combobox(
-            daily_time_frame,
+            time_frame,
             textvariable=self.minute,
             values=minute_values,
             width=5,
-            state="readonly"
+            state="readonly",
         )
-        minute_combo.grid(row=0, column=2, sticky="w", padx=(5, 0))
+        minute_combo.grid(row=0, column=1, padx=(5, 0))
+        self.daily_controls.extend([hour_combo, minute_combo])
 
-        # ==== SECCIÓN DE REPORTES SEMANALES (COLUMNA DERECHA) ====
+        # ----- Configuración semanal -----
         weekly_frame = ttk.LabelFrame(
             main_frame,
-            text="Configuración de Reportes Semanales",
-            padding="15 15 15 15"
+            text="Reportes Semanales",
+            padding="15 15 15 15",
         )
-        weekly_frame.grid(row=1, column=1, sticky="nsew", padx=(10, 0))
+        weekly_frame.grid(row=1, column=1, sticky="nsew", padx=(12, 0))
 
-        # Switch para activar/desactivar programación semanal
-        weekly_enable_switch = ttk.Checkbutton(
+        enable_weekly = ttk.Checkbutton(
             weekly_frame,
-            text="Activar envío automático de reportes semanales",
+            text="Activar envío automático semanal",
             variable=self.weekly_enabled,
-            command=self._toggle_weekly_scheduler
+            command=self._toggle_weekly_scheduler,
         )
-        weekly_enable_switch.grid(row=0, column=0, columnspan=2, sticky="w", pady=(0, 15))
+        enable_weekly.grid(row=0, column=0, columnspan=2, sticky="w", pady=(0, 10))
 
-        # Frame para día de la semana del reporte semanal
         weekly_day_frame = ttk.LabelFrame(
             weekly_frame,
-            text="Día de envío semanal",
-            padding="10 10 10 10"
+            text="Día de ejecución",
+            padding="10 10 10 10",
         )
-        weekly_day_frame.grid(row=1, column=0, columnspan=2, sticky="nsew", pady=(0, 15))
+        weekly_day_frame.grid(row=1, column=0, columnspan=2, sticky="nsew", pady=(0, 10))
 
-        # Combobox para seleccionar el día de la semana
         weekly_day_combo = ttk.Combobox(
             weekly_day_frame,
-            textvariable=self.weekly_day,
-            values=["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"],
             state="readonly",
-            width=15
+            values=list(self.DAY_NAMES.values()),
+            width=20,
         )
-        weekly_day_combo.grid(row=0, column=0, pady=5)
+        weekly_day_combo.grid(row=0, column=0, sticky="w")
+        self.weekly_controls.append(weekly_day_combo)
 
-        # Establecer textos legibles para el combobox
-        weekly_day_combo.configure(values=list(day_names.values()))
+        # Sincronizar valor mostrado con clave interna
+        inverse_day_names = {v: k for k, v in self.DAY_NAMES.items()}
+        weekly_day_combo.set(self.DAY_NAMES.get(self.weekly_day.get(), "Viernes"))
 
-        # Mapeo inverso para convertir nombres legibles a claves
-        self.day_keys = {v: k for k, v in day_names.items()}
-
-        # Escuchar cambios en el combobox para actualizar la variable
         def on_weekly_day_change(event):
-            selected_day_name = weekly_day_combo.get()
-            if selected_day_name in self.day_keys:
-                self.weekly_day.set(self.day_keys[selected_day_name])
+            selected = weekly_day_combo.get()
+            if selected in inverse_day_names:
+                self.weekly_day.set(inverse_day_names[selected])
 
         weekly_day_combo.bind("<<ComboboxSelected>>", on_weekly_day_change)
 
-        # Establecer valor inicial visible
-        for day_name, day_key in self.day_keys.items():
-            if day_key == self.weekly_day.get():
-                weekly_day_combo.set(day_name)
-                break
-
-        # Frame para hora de envío semanal
         weekly_time_frame = ttk.LabelFrame(
             weekly_frame,
-            text="Hora de envío semanal",
-            padding="10 10 10 10"
+            text="Hora semanal",
+            padding="10 10 10 10",
         )
-        weekly_time_frame.grid(row=2, column=0, columnspan=2, sticky="nsew", pady=(0, 10))
+        weekly_time_frame.grid(row=2, column=0, columnspan=2, sticky="nsew")
 
-        # Selector de hora para reportes semanales
         weekly_hour_combo = ttk.Combobox(
             weekly_time_frame,
             textvariable=self.weekly_hour,
             values=hour_values,
             width=5,
-            state="readonly"
+            state="readonly",
         )
-        weekly_hour_combo.grid(row=0, column=0, sticky="e", padx=(0, 5))
-
-        ttk.Label(weekly_time_frame, text=":").grid(row=0, column=1)
-
+        weekly_hour_combo.grid(row=0, column=0, padx=(0, 5))
         weekly_minute_combo = ttk.Combobox(
             weekly_time_frame,
             textvariable=self.weekly_minute,
             values=minute_values,
             width=5,
-            state="readonly"
+            state="readonly",
         )
-        weekly_minute_combo.grid(row=0, column=2, sticky="w", padx=(5, 0))
+        weekly_minute_combo.grid(row=0, column=1, padx=(5, 0))
+        self.weekly_controls.extend([weekly_hour_combo, weekly_minute_combo])
 
-        # Explicación del reporte semanal
-        weekly_note = ttk.Label(
-            weekly_frame,
-            text="El reporte semanal contiene datos acumulados de todos\nlos reportes diarios de la semana.",
+        # ----- Configuración mensual -----
+        monthly_frame = ttk.LabelFrame(
+            main_frame,
+            text="Reportes Mensuales",
+            padding="15 15 15 15",
+        )
+        monthly_frame.grid(row=2, column=0, columnspan=2, sticky="nsew", pady=(20, 0))
+
+        enable_monthly = ttk.Checkbutton(
+            monthly_frame,
+            text="Activar envío automático mensual",
+            variable=self.monthly_enabled,
+            command=self._toggle_monthly_scheduler,
+        )
+        enable_monthly.grid(row=0, column=0, sticky="w", pady=(0, 10))
+
+        day_type_frame = ttk.Frame(monthly_frame)
+        day_type_frame.grid(row=1, column=0, sticky="w", pady=(0, 10))
+
+        specific_radio = ttk.Radiobutton(
+            day_type_frame,
+            text="Día específico del mes",
+            variable=self.monthly_day_type,
+            value="specific",
+            command=self._update_day_selection,
+        )
+        specific_radio.grid(row=0, column=0, padx=(0, 15))
+        last_day_radio = ttk.Radiobutton(
+            day_type_frame,
+            text="Último día del mes",
+            variable=self.monthly_day_type,
+            value="last",
+            command=self._update_day_selection,
+        )
+        last_day_radio.grid(row=0, column=1)
+        self.monthly_controls.extend([specific_radio, last_day_radio])
+
+        self.specific_day_frame = ttk.Frame(monthly_frame)
+        self.specific_day_frame.grid(row=2, column=0, sticky="w")
+        ttk.Label(self.specific_day_frame, text="Día del mes:").grid(row=0, column=0, padx=(0, 10))
+        day_values = [str(i) for i in range(1, 32)]
+        self.day_combo = ttk.Combobox(
+            self.specific_day_frame,
+            textvariable=self.monthly_day,
+            values=day_values,
+            width=5,
+            state="readonly",
+        )
+        self.day_combo.grid(row=0, column=1)
+        self.monthly_controls.append(self.day_combo)
+
+        monthly_time_frame = ttk.LabelFrame(
+            monthly_frame,
+            text="Hora mensual",
+            padding="10 10 10 10",
+        )
+        monthly_time_frame.grid(row=3, column=0, sticky="nsew", pady=(15, 0))
+
+        monthly_hour_combo = ttk.Combobox(
+            monthly_time_frame,
+            textvariable=self.monthly_hour,
+            values=hour_values,
+            width=5,
+            state="readonly",
+        )
+        monthly_hour_combo.grid(row=0, column=0, padx=(0, 5))
+        monthly_minute_combo = ttk.Combobox(
+            monthly_time_frame,
+            textvariable=self.monthly_minute,
+            values=minute_values,
+            width=5,
+            state="readonly",
+        )
+        monthly_minute_combo.grid(row=0, column=1, padx=(5, 0))
+        self.monthly_controls.extend([monthly_hour_combo, monthly_minute_combo])
+
+        ttk.Label(
+            monthly_frame,
+            text="Si se selecciona un día inexistente para un mes determinado, se enviará el último día hábil",
             font=("Arial", 9),
             foreground="gray",
-            justify="center"
-        )
-        weekly_note.grid(row=3, column=0, columnspan=2, sticky="ew", pady=(5, 0))
+        ).grid(row=4, column=0, sticky="w", pady=(10, 0))
 
-        # Nota explicativa general (abajo de todo, ocupa ambas columnas)
+        # Nota general e instrucciones
         note_label = ttk.Label(
             main_frame,
-            text="Los reportes se generarán y enviarán automáticamente en los días y horas seleccionados.\nSe implementará prevención de duplicados para evitar envíos múltiples.",
+            text=(
+                "Los reportes se generarán y enviarán automáticamente según la configuración.\n"
+                "El sistema evita duplicados y reinicia los cálculos tras cada actualización."
+            ),
             font=("Arial", 9),
             foreground="gray",
-            justify="center"
+            justify="center",
         )
-        note_label.grid(row=2, column=0, columnspan=2, sticky="ew", pady=(20, 20))
+        note_label.grid(row=3, column=0, columnspan=2, pady=(20, 10))
 
-        # Botones (al fondo, centrados)
+        # Botones inferiores
         button_frame = ttk.Frame(main_frame)
-        button_frame.grid(row=3, column=0, columnspan=2, sticky="ew")
+        button_frame.grid(row=4, column=0, columnspan=2, sticky="ew")
         button_frame.columnconfigure(0, weight=1)
         button_frame.columnconfigure(1, weight=1)
 
-        save_btn = ttk.Button(
-            button_frame,
-            text="Guardar",
-            command=self._save_config,
-            width=15
-        )
-        save_btn.grid(row=0, column=0, padx=(0, 5), sticky="e")
+        save_btn = ttk.Button(button_frame, text="Guardar", command=self._save_config, width=18)
+        save_btn.grid(row=0, column=0, padx=(0, 10), sticky="e")
 
-        close_btn = ttk.Button(
-            button_frame,
-            text="Cerrar",
-            command=self.modal.destroy,
-            width=15
-        )
-        close_btn.grid(row=0, column=1, padx=(5, 0), sticky="w")
+        close_btn = ttk.Button(button_frame, text="Cerrar", command=self._handle_close, width=18)
+        close_btn.grid(row=0, column=1, padx=(10, 0), sticky="w")
 
-        # Configurar estado inicial
-        self._toggle_daily_scheduler()
-        self._toggle_weekly_scheduler()
+    # ------------------------------------------------------------------
+    # Manejo de estado y validaciones
+    # ------------------------------------------------------------------
+    def _toggle_daily_scheduler(self):
+        state = "normal" if self.enabled.get() else "disabled"
+        for widget in self.daily_controls:
+            widget.configure(state=state)
+
+    def _toggle_weekly_scheduler(self):
+        state = "normal" if self.weekly_enabled.get() else "disabled"
+        for widget in self.weekly_controls:
+            widget.configure(state=state)
+
+    def _toggle_monthly_scheduler(self):
+        state = "normal" if self.monthly_enabled.get() else "disabled"
+        for widget in self.monthly_controls:
+            widget.configure(state=state)
+        self._update_day_selection()
+
+    def _update_day_selection(self):
+        show_specific = self.monthly_day_type.get() == "specific"
+        if show_specific:
+            self.specific_day_frame.grid()
+            state = "readonly" if self.monthly_enabled.get() else "disabled"
+            self.day_combo.configure(state=state)
+        else:
+            self.specific_day_frame.grid_remove()
+
+    def _handle_close(self):
+        if self.on_close:
+            try:
+                self.on_close()
+            except Exception:
+                pass
+        self.modal.destroy()
+
+    # ------------------------------------------------------------------
+    # Carga y guardado de configuración
+    # ------------------------------------------------------------------
+    def _load_config(self):
+        raw = self._read_config_file()
+        config = self._normalize_config(raw)
+
+        daily = config["daily"]
+        self.enabled.set(daily.get("enabled", False))
+        for day_key, var in self.days.items():
+            var.set(daily.get("days", {}).get(day_key, False))
+        daily_time = daily.get("time", "08:00").split(":")
+        self.hour.set(f"{int(daily_time[0]):02d}")
+        self.minute.set(f"{int(daily_time[1]):02d}")
+
+        weekly = config["weekly"]
+        self.weekly_enabled.set(weekly.get("enabled", False))
+        self.weekly_day.set(weekly.get("day", "friday"))
+        weekly_time = weekly.get("time", "16:00").split(":")
+        self.weekly_hour.set(f"{int(weekly_time[0]):02d}")
+        self.weekly_minute.set(f"{int(weekly_time[1]):02d}")
+
+        monthly = config["monthly"]
+        self.monthly_enabled.set(monthly.get("enabled", False))
+        day_value = monthly.get("day", "1")
+        if day_value == "last":
+            self.monthly_day_type.set("last")
+        else:
+            self.monthly_day_type.set("specific")
+            self.monthly_day.set(str(day_value))
+        monthly_time = monthly.get("time", "09:00").split(":")
+        self.monthly_hour.set(f"{int(monthly_time[0]):02d}")
+        self.monthly_minute.set(f"{int(monthly_time[1]):02d}")
+
+        if self.bottom_panel:
+            self.bottom_panel.add_log_entry("Configuración de programación cargada")
+
+    def _save_config(self):
+        if self.enabled.get() and not any(var.get() for var in self.days.values()):
+            messagebox.showerror("Error", "Debe seleccionar al menos un día para los reportes diarios")
+            return
+
+        if self.monthly_enabled.get() and self.monthly_day_type.get() == "specific":
+            try:
+                day_value = int(self.monthly_day.get())
+                if day_value < 1 or day_value > 31:
+                    raise ValueError
+            except ValueError:
+                messagebox.showerror("Error", "El día del reporte mensual debe estar entre 1 y 31")
+                return
+
+        daily_config = {
+            "enabled": self.enabled.get(),
+            "days": {day: var.get() for day, var in self.days.items()},
+            "time": f"{self.hour.get()}:{self.minute.get()}",
+        }
+
+        weekly_config = {
+            "enabled": self.weekly_enabled.get(),
+            "day": self.weekly_day.get(),
+            "time": f"{self.weekly_hour.get()}:{self.weekly_minute.get()}",
+        }
+
+        if self.monthly_day_type.get() == "last":
+            monthly_day = "last"
+        else:
+            monthly_day = str(int(self.monthly_day.get()))
+
+        monthly_config = {
+            "enabled": self.monthly_enabled.get(),
+            "day": monthly_day,
+            "time": f"{self.monthly_hour.get()}:{self.monthly_minute.get()}",
+        }
+
+        existing = self._normalize_config(self._read_config_file())
+        existing["daily"] = daily_config
+        existing["weekly"] = weekly_config
+        existing["monthly"] = monthly_config
+        existing["last_update"] = datetime.now().isoformat()
+
+        try:
+            with open(self.config_file, "w", encoding="utf-8") as file:
+                json.dump(existing, file, indent=4, ensure_ascii=False)
+
+            if self.bottom_panel:
+                logs = []
+                logs.append(
+                    "✅ Programación diaria "
+                    + ("activada" if daily_config["enabled"] else "desactivada")
+                )
+                logs.append(
+                    "✅ Programación semanal "
+                    + ("activada" if weekly_config["enabled"] else "desactivada")
+                )
+                logs.append(
+                    "✅ Programación mensual "
+                    + ("activada" if monthly_config["enabled"] else "desactivada")
+                )
+                for log in logs:
+                    self.bottom_panel.add_log_entry(log)
+
+            messagebox.showinfo("Éxito", "Configuración de programación guardada correctamente")
+        except Exception as exc:
+            error_msg = f"Error al guardar configuración: {exc}"
+            if self.bottom_panel:
+                self.bottom_panel.add_log_entry(error_msg)
+            messagebox.showerror("Error", error_msg)
+
+    # ------------------------------------------------------------------
+    # Helpers de normalización
+    # ------------------------------------------------------------------
+    def _read_config_file(self) -> Dict:
+        if not self.config_file.exists():
+            return {}
+        try:
+            with open(self.config_file, "r", encoding="utf-8") as file:
+                return json.load(file)
+        except Exception:
+            return {}
+
+    def _normalize_config(self, raw: Optional[Dict]) -> Dict[str, Dict]:
+        default = {
+            "daily": {
+                "enabled": False,
+                "days": {day: False for day in self.DAY_NAMES},
+                "time": "08:00",
+            },
+            "weekly": {"enabled": False, "day": "friday", "time": "16:00"},
+            "monthly": {"enabled": False, "day": "1", "time": "09:00"},
+        }
+
+        if not isinstance(raw, dict):
+            return default
+
+        # Compatibilidad con formato legacy (claves diarias en raíz)
+        daily_source = raw.get("daily") if isinstance(raw.get("daily"), dict) else raw
+        daily = {
+            "enabled": bool(daily_source.get("enabled", False)),
+            "days": self._sanitize_day_map(daily_source.get("days", {})),
+            "time": self._sanitize_time_string(daily_source.get("time"), "08:00"),
+        }
+
+        weekly_source = raw.get("weekly", {})
+        weekly = {
+            "enabled": bool(weekly_source.get("enabled", False)),
+            "day": weekly_source.get("day", "friday") if weekly_source.get("day") in self.DAY_NAMES else "friday",
+            "time": self._sanitize_time_string(weekly_source.get("time"), "16:00"),
+        }
+
+        monthly_source = raw.get("monthly", {})
+        monthly_day = monthly_source.get("day", "1")
+        if monthly_day != "last":
+            try:
+                monthly_day = str(max(1, min(31, int(monthly_day))))
+            except (TypeError, ValueError):
+                monthly_day = "1"
+
+        monthly = {
+            "enabled": bool(monthly_source.get("enabled", False)),
+            "day": monthly_day,
+            "time": self._sanitize_time_string(monthly_source.get("time"), "09:00"),
+        }
+
+        return {"daily": daily, "weekly": weekly, "monthly": monthly}
+
+    def _sanitize_day_map(self, day_map: Dict) -> Dict[str, bool]:
+        sanitized = {}
+        for day in self.DAY_NAMES:
+            sanitized[day] = bool(day_map.get(day, False)) if isinstance(day_map, dict) else False
+        return sanitized
+
+    def _sanitize_time_string(self, value: Optional[str], default: str) -> str:
+        if not value or not isinstance(value, str):
+            return default
+        try:
+            hour, minute = value.split(":")
+            hour_int = max(0, min(23, int(hour)))
+            minute_int = max(0, min(59, int(minute)))
+            return f"{hour_int:02d}:{minute_int:02d}"
+        except (ValueError, TypeError):
+            return default
 
     def _center_window(self):
-        """Centra la ventana en la pantalla."""
         self.modal.update_idletasks()
         width = self.modal.winfo_width()
         height = self.modal.winfo_height()
         x = (self.modal.winfo_screenwidth() // 2) - (width // 2)
         y = (self.modal.winfo_screenheight() // 2) - (height // 2)
         self.modal.geometry(f"{width}x{height}+{x}+{y}")
-
-    def _toggle_daily_scheduler(self):
-        """Habilita/deshabilita los controles de programación diaria según el estado del switch."""
-        state = "normal" if self.enabled.get() else "disabled"
-
-        # Aplicar estado a todos los widgets de días diarios
-        for child in self.modal.winfo_children():
-            if isinstance(child, ttk.Frame):
-                for grandchild in child.winfo_children():
-                    if isinstance(grandchild, ttk.LabelFrame) and "Reportes Diarios" in grandchild["text"]:
-                        for ggchild in grandchild.winfo_children():
-                            if isinstance(ggchild, ttk.LabelFrame):
-                                for gggchild in ggchild.winfo_children():
-                                    if isinstance(gggchild, ttk.Checkbutton) or isinstance(gggchild, ttk.Combobox):
-                                        gggchild.configure(state=state)
-
-    def _toggle_weekly_scheduler(self):
-        """Habilita/deshabilita los controles de programación semanal según el estado del switch."""
-        state = "normal" if self.weekly_enabled.get() else "disabled"
-
-        # Aplicar estado a todos los widgets de programación semanal
-        for child in self.modal.winfo_children():
-            if isinstance(child, ttk.Frame):
-                for grandchild in child.winfo_children():
-                    if isinstance(grandchild, ttk.LabelFrame) and "Reportes Semanales" in grandchild["text"]:
-                        for ggchild in grandchild.winfo_children():
-                            if isinstance(ggchild, (ttk.LabelFrame, ttk.Frame)):
-                                for gggchild in ggchild.winfo_children():
-                                    if isinstance(gggchild, (ttk.Checkbutton, ttk.Combobox)):
-                                        gggchild.configure(state=state)
-
-    def _load_config(self):
-        """Carga configuración guardada."""
-        try:
-            if os.path.exists(self.config_file):
-                with open(self.config_file, "r", encoding="utf-8") as file:
-                    config = json.load(file)
-
-                    # Cargar estado de reportes diarios
-                    self.enabled.set(config.get("enabled", False))
-
-                    # Cargar días
-                    days_config = config.get("days", {})
-                    for day in self.days:
-                        self.days[day].set(days_config.get(day, False))
-
-                    # Cargar hora
-                    time_config = config.get("time", "08:00").split(":")
-                    self.hour.set(time_config[0])
-                    self.minute.set(time_config[1])
-
-                    # Cargar configuración de reportes semanales
-                    weekly_config = config.get("weekly", {})
-                    self.weekly_enabled.set(weekly_config.get("enabled", False))
-                    self.weekly_day.set(weekly_config.get("day", "friday"))
-
-                    # Cargar hora semanal
-                    weekly_time_config = weekly_config.get("time", "16:00").split(":")
-                    self.weekly_hour.set(weekly_time_config[0])
-                    self.weekly_minute.set(weekly_time_config[1])
-
-                    if self.bottom_panel:
-                        self.bottom_panel.add_log_entry("Configuración de programación cargada")
-
-        except Exception as e:
-            if self.bottom_panel:
-                self.bottom_panel.add_log_entry(f"Error al cargar configuración de programación: {e}")
-
-    def _save_config(self):
-        """Guarda la configuración de programación."""
-        # Validar configuración diaria
-        if self.enabled.get():
-            any_day_selected = any(self.days[day].get() for day in self.days)
-            if not any_day_selected:
-                messagebox.showerror("Error", "Debe seleccionar al menos un día de la semana para los reportes diarios")
-                return
-
-        # Crear configuración
-        days_config = {day: self.days[day].get() for day in self.days}
-        time_config = f"{self.hour.get()}:{self.minute.get()}"
-
-        # Configuración de reportes semanales
-        weekly_time_config = f"{self.weekly_hour.get()}:{self.weekly_minute.get()}"
-        weekly_config = {
-            "enabled": self.weekly_enabled.get(),
-            "day": self.weekly_day.get(),
-            "time": weekly_time_config
-        }
-
-        config = {
-            "enabled": self.enabled.get(),
-            "days": days_config,
-            "time": time_config,
-            "weekly": weekly_config,
-            "last_update": datetime.now().isoformat()
-        }
-
-        try:
-            with open(self.config_file, "w", encoding="utf-8") as file:
-                json.dump(config, file, indent=4, ensure_ascii=False)
-
-            if self.bottom_panel:
-                log_message = []
-
-                if self.enabled.get():
-                    log_message.append("✅ Programación de reportes diarios activada")
-                else:
-                    log_message.append("✅ Programación de reportes diarios desactivada")
-
-                if self.weekly_enabled.get():
-                    log_message.append("✅ Programación de reportes semanales activada")
-                else:
-                    log_message.append("✅ Programación de reportes semanales desactivada")
-
-                self.bottom_panel.add_log_entry(" y ".join(log_message))
-
-            messagebox.showinfo("Éxito", "Configuración de programación guardada correctamente")
-
-        except Exception as e:
-            error_msg = f"Error al guardar configuración: {e}"
-            if self.bottom_panel:
-                self.bottom_panel.add_log_entry(error_msg)
-            messagebox.showerror("Error", error_msg)

--- a/services/scheduler_service.py
+++ b/services/scheduler_service.py
@@ -1,891 +1,590 @@
-# scheduler_service.py
-"""
-Servicio modular para programación de tareas automáticas.
-Implementa servicios especializados para programación diaria, semanal y mensual
-con manejo robusto de hilos independientes y cálculo inteligente de próximas ejecuciones.
+"""Servicios para programación automática de reportes.
+
+Este módulo implementa un programador unificado capaz de manejar
+configuraciones diarias, semanales y mensuales utilizando un único hilo
+de fondo. Mejora la lógica previa al consolidar cálculos de próximas
+ejecuciones, tolerancias de tiempo flexibles y reinicios controlados
+cada vez que la configuración cambia.
 """
 
-import json
-import time
-import threading
-from datetime import datetime, timedelta, date
-import os
-from pathlib import Path
-from abc import ABC, abstractmethod
+from __future__ import annotations
+
 import calendar
+import json
+import threading
+from datetime import date, datetime, timedelta
+from pathlib import Path
+from typing import Callable, Dict, Iterable, Optional
 
 
-class BaseSchedulerService(ABC):
-    """Clase base abstracta para servicios de programación."""
+class UnifiedSchedulerService:
+    """Programa tareas automáticas diarias, semanales y mensuales.
 
-    def __init__(self, config_file, log_callback=None):
-        """
-        Inicializa el servicio base de programación.
+    La clase centraliza toda la lógica de programación en un único hilo
+    de fondo. Cada tipo de frecuencia (diaria, semanal y mensual) puede
+    tener su propio callback y configuración independiente, pero el
+    servicio se encarga de coordinar la ejecución evitando duplicados y
+    manejando periodos de tolerancia para no perder ejecuciones si el
+    hilo se despierta unos minutos tarde.
+    """
 
-        Args:
-            config_file (Path): Ruta al archivo de configuración
-            log_callback (callable, optional): Función para registrar logs
-        """
-        self.config_file = config_file
+    DAY_ORDER = [
+        "monday",
+        "tuesday",
+        "wednesday",
+        "thursday",
+        "friday",
+        "saturday",
+        "sunday",
+    ]
+
+    FREQUENCIES = ("daily", "weekly", "monthly")
+
+    def __init__(
+        self,
+        config_file: Path,
+        callbacks: Optional[Dict[str, Callable[[], bool]]] = None,
+        log_callback: Optional[Callable[[str], None]] = None,
+    ) -> None:
+        """Inicializa el servicio unificado de programación."""
+
+        self.config_file = Path(config_file)
+        self.callbacks = callbacks or {}
         self.log_callback = log_callback
 
-        # Control de hilos
-        self.scheduler_thread = None
         self.stop_event = threading.Event()
+        self.thread: Optional[threading.Thread] = None
+        self.lock = threading.Lock()
+
+        self.current_config: Dict[str, Dict] = {}
+        self.next_executions: Dict[str, Optional[datetime]] = {
+            freq: None for freq in self.FREQUENCIES
+        }
+        self.last_execution_times: Dict[str, Optional[datetime]] = {
+            freq: None for freq in self.FREQUENCIES
+        }
+
         self.is_running = False
-        self.last_execution_time = None
 
-        # Lock para operaciones thread-safe
-        self.operation_lock = threading.Lock()
+        # Asegurar que el directorio exista para evitar errores al leer/escribir
+        self.config_file.parent.mkdir(parents=True, exist_ok=True)
 
-        # Estado del scheduler
-        self.current_config = None
-        self.next_execution = None
+        self._setup_scheduler()
 
-    def _load_config(self):
-        """
-        Carga configuración de programación de manera segura.
+    # ------------------------------------------------------------------
+    # Configuración y carga de datos
+    # ------------------------------------------------------------------
+    def _setup_scheduler(self) -> None:
+        """Carga configuración inicial y arranca el hilo si corresponde."""
 
-        Returns:
-            dict: Configuración cargada o None si no existe
-        """
-        try:
-            if os.path.exists(self.config_file):
-                with open(self.config_file, "r", encoding="utf-8") as file:
-                    config = json.load(file)
+        self.current_config = self._load_config()
 
-                # Validar configuración básica
-                if not isinstance(config, dict):
-                    return None
-
-                return config
-        except Exception as e:
-            self._log(f"❌ Error al cargar configuración de programación: {e}")
-        return None
-
-    def _start_scheduler_thread(self):
-        """Inicia el hilo que ejecuta el programador de manera segura."""
-        # Detener hilo existente si está corriendo
-        if self.is_running:
-            self._stop_scheduler_thread()
-
-        try:
-            # Limpiar evento de parada
-            self.stop_event.clear()
-
-            # Crear e iniciar nuevo hilo
-            self.scheduler_thread = threading.Thread(
-                target=self._run_scheduler,
-                name=f"{self.__class__.__name__}Thread",
-                daemon=True
+        if self._any_frequency_enabled(self.current_config):
+            self._start_thread()
+        else:
+            self._log(
+                "Programación automática desactivada: no hay frecuencias habilitadas"
             )
 
-            self.is_running = True
-            self.scheduler_thread.start()
+    def _load_config(self) -> Dict[str, Dict]:
+        """Carga y normaliza la configuración de programación."""
 
-            self._log(f"📋 Hilo del programador {self.__class__.__name__} iniciado")
+        raw_config = self._read_config_file()
+        normalized = self._normalize_config(raw_config)
+        return normalized
 
-        except Exception as e:
+    def _read_config_file(self) -> Dict:
+        """Lee el archivo de configuración si existe."""
+
+        if not self.config_file.exists():
+            return {}
+
+        try:
+            with open(self.config_file, "r", encoding="utf-8") as file:
+                return json.load(file)
+        except Exception as exc:  # pragma: no cover - errores raros de lectura
+            self._log(f"❌ Error al leer configuración de programación: {exc}")
+            return {}
+
+    def _normalize_config(self, raw_config: Optional[Dict]) -> Dict[str, Dict]:
+        """Normaliza la configuración para asegurar llaves y valores válidos."""
+
+        default_config = {
+            "daily": {
+                "enabled": False,
+                "days": {day: False for day in self.DAY_ORDER},
+                "time": "08:00",
+            },
+            "weekly": {
+                "enabled": False,
+                "day": "friday",
+                "time": "16:00",
+            },
+            "monthly": {
+                "enabled": False,
+                "day": "1",
+                "time": "09:00",
+            },
+        }
+
+        if not raw_config:
+            return default_config
+
+        config = default_config.copy()
+        config["daily"] = {**default_config["daily"], **self._extract_daily(raw_config)}
+        config["weekly"] = {
+            **default_config["weekly"],
+            **self._extract_weekly(raw_config.get("weekly")),
+        }
+        config["monthly"] = {
+            **default_config["monthly"],
+            **self._extract_monthly(raw_config.get("monthly")),
+        }
+        return config
+
+    def _extract_daily(self, raw_config: Dict) -> Dict:
+        """Extrae configuración diaria soportando formatos heredados."""
+
+        daily_config = raw_config.get("daily")
+        if isinstance(daily_config, dict):
+            source = daily_config
+        else:
+            # Formato legacy donde las claves estaban en la raíz del JSON
+            source = raw_config
+
+        enabled = bool(source.get("enabled", False))
+        time_value = self._sanitize_time(source.get("time"), default="08:00")
+        days_raw = source.get("days", {})
+        days = {day: bool(days_raw.get(day, False)) for day in self.DAY_ORDER}
+
+        return {"enabled": enabled, "time": time_value, "days": days}
+
+    def _extract_weekly(self, weekly_config: Optional[Dict]) -> Dict:
+        """Extrae configuración semanal normalizada."""
+
+        if not isinstance(weekly_config, dict):
+            weekly_config = {}
+
+        day = weekly_config.get("day", "friday")
+        if day not in self.DAY_ORDER:
+            day = "friday"
+
+        time_value = self._sanitize_time(weekly_config.get("time"), default="16:00")
+
+        return {
+            "enabled": bool(weekly_config.get("enabled", False)),
+            "day": day,
+            "time": time_value,
+        }
+
+    def _extract_monthly(self, monthly_config: Optional[Dict]) -> Dict:
+        """Extrae configuración mensual normalizada."""
+
+        if not isinstance(monthly_config, dict):
+            monthly_config = {}
+
+        day_value = monthly_config.get("day", "1")
+        if isinstance(day_value, int):
+            day_value = str(day_value)
+
+        if isinstance(day_value, str):
+            day_value = day_value.strip() or "1"
+            if day_value != "last":
+                try:
+                    number = int(day_value)
+                    if number < 1:
+                        number = 1
+                    if number > 31:
+                        number = 31
+                    day_value = str(number)
+                except ValueError:
+                    day_value = "1"
+        else:
+            day_value = "1"
+
+        time_value = self._sanitize_time(monthly_config.get("time"), default="09:00")
+
+        return {
+            "enabled": bool(monthly_config.get("enabled", False)),
+            "day": day_value,
+            "time": time_value,
+        }
+
+    def _sanitize_time(self, value: Optional[str], default: str) -> str:
+        """Normaliza una cadena de hora en formato HH:MM."""
+
+        if not value or not isinstance(value, str):
+            return default
+
+        parts = value.split(":")
+        try:
+            hour = int(parts[0])
+            minute = int(parts[1]) if len(parts) > 1 else 0
+        except (TypeError, ValueError):
+            return default
+
+        hour = max(0, min(23, hour))
+        minute = max(0, min(59, minute))
+        return f"{hour:02d}:{minute:02d}"
+
+    # ------------------------------------------------------------------
+    # Gestión del hilo del programador
+    # ------------------------------------------------------------------
+    def _start_thread(self) -> None:
+        """Inicia el hilo del programador unificado."""
+
+        if self.thread and self.thread.is_alive():
+            self.stop()
+
+        self.stop_event.clear()
+
+        self.thread = threading.Thread(
+            target=self._run_scheduler,
+            name="UnifiedSchedulerThread",
+            daemon=True,
+        )
+        self.thread.start()
+        self.is_running = True
+        self._log("📋 Hilo de programación automática iniciado")
+
+    def stop(self) -> None:
+        """Detiene el hilo de programación si está en ejecución."""
+
+        if not self.thread or not self.thread.is_alive():
             self.is_running = False
-            self._log(f"❌ Error al iniciar hilo del programador: {e}")
-
-    def _stop_scheduler_thread(self):
-        """Detiene el hilo del programador de manera segura."""
-        if not self.is_running:
             return
 
-        try:
-            # Señalar parada
-            self.stop_event.set()
+        self._log("🛑 Deteniendo programación automática...")
+        self.stop_event.set()
+        self.thread.join(timeout=5)
+        self.thread = None
+        self.is_running = False
+        self._log("🛑 Programación automática detenida")
 
-            # Esperar a que termine el hilo (con timeout)
-            if self.scheduler_thread and self.scheduler_thread.is_alive():
-                self.scheduler_thread.join(timeout=5.0)
+    def restart(self) -> None:
+        """Recarga configuración y reinicia el hilo si es necesario."""
 
-                # Si no terminó, informar (aunque no forzamos la terminación)
-                if self.scheduler_thread.is_alive():
-                    self._log("⚠️ Hilo del programador no terminó gracefully")
+        self._log("♻️ Reiniciando servicio de programación automática...")
+        self.stop()
+        self.current_config = self._load_config()
+        if self._any_frequency_enabled(self.current_config):
+            self._start_thread()
+        else:
+            self._log(
+                "Programación automática desactivada tras la actualización de configuración"
+            )
 
-            self.is_running = False
-            self.scheduler_thread = None
+    # ------------------------------------------------------------------
+    # Lógica principal del scheduler
+    # ------------------------------------------------------------------
+    def _run_scheduler(self) -> None:
+        """Bucle principal que vigila próximas ejecuciones."""
 
-            self._log(f"🛑 Hilo del programador {self.__class__.__name__} detenido")
+        self._log("▶️ Bucle del programador unificado iniciado")
+        consecutive_errors = 0
 
-        except Exception as e:
-            self._log(f"❌ Error al detener hilo del programador: {e}")
+        while not self.stop_event.is_set():
+            wait_seconds = 60  # Valor por defecto si no hay próximas ejecuciones
 
-    @abstractmethod
-    def _run_scheduler(self):
-        """Función que ejecuta el programador en segundo plano."""
-        pass
+            try:
+                config = self._load_config()
+                self.current_config = config
 
-    @abstractmethod
-    def _calculate_next_execution(self, config, current_time):
-        """Calcula la próxima ejecución programada."""
-        pass
+                now = datetime.now()
+                due_tasks = self._collect_due_tasks(config, now)
 
-    @abstractmethod
-    def _execute_scheduled_task(self):
-        """Ejecuta la tarea programada."""
-        pass
+                for frequency in due_tasks:
+                    self._execute_task(frequency)
 
-    def stop(self):
-        """Detiene el programador de manera segura."""
-        if self.is_running:
-            self._log(f"🛑 Deteniendo servicio de programación {self.__class__.__name__}...")
-            self._stop_scheduler_thread()
+                self.next_executions = self._calculate_next_executions(config, now)
+                wait_seconds = self._compute_sleep_interval(now, self.next_executions)
+                consecutive_errors = 0
 
-    def restart(self):
-        """Reinicia el programador con la configuración actual de manera segura."""
-        self._log(f"📋 Reiniciando servicio de programación {self.__class__.__name__}...")
+            except Exception as exc:  # pragma: no cover - fallos inesperados
+                consecutive_errors += 1
+                wait_seconds = min(300, 30 * consecutive_errors)
+                self._log(f"💥 Error en el bucle del programador: {exc}")
 
-        try:
-            # Detener si está corriendo
-            if self.is_running:
-                self._stop_scheduler_thread()
+            if self.stop_event.wait(wait_seconds):
+                break
 
-            # Pequeña pausa para asegurar limpieza
-            time.sleep(1)
+        self._log("⏹️ Bucle del programador unificado finalizado")
 
-            # Reconfigurar
-            self._setup_scheduler()
+    def _collect_due_tasks(self, config: Dict[str, Dict], now: datetime) -> Iterable[str]:
+        """Determina qué frecuencias deben ejecutarse en este instante."""
 
-        except Exception as e:
-            self._log(f"❌ Error al reiniciar programación {self.__class__.__name__}: {e}")
+        tolerance = timedelta(minutes=5)
+        due_tasks = []
 
-    @abstractmethod
-    def _setup_scheduler(self):
-        """Configura el programador según los ajustes guardados."""
-        pass
+        # Diarios
+        daily = config.get("daily", {})
+        if daily.get("enabled"):
+            day_key = self.DAY_ORDER[now.weekday()]
+            if daily.get("days", {}).get(day_key, False):
+                scheduled = self._build_datetime_from_time(now.date(), daily.get("time", "08:00"))
+                if self._should_run("daily", scheduled, now, tolerance):
+                    due_tasks.append("daily")
 
-    def get_status(self):
-        """
-        Obtiene el estado actual del programador.
+        # Semanales
+        weekly = config.get("weekly", {})
+        if weekly.get("enabled"):
+            if weekly.get("day") == self.DAY_ORDER[now.weekday()]:
+                scheduled = self._build_datetime_from_time(now.date(), weekly.get("time", "16:00"))
+                if self._should_run("weekly", scheduled, now, tolerance, period="week"):
+                    due_tasks.append("weekly")
 
-        Returns:
-            dict: Estado actual del programador
-        """
-        try:
-            status = {
-                "is_running": self.is_running,
-                "is_enabled": False,
-                "next_execution": None,
-                "last_execution": self.last_execution_time,
-                "current_config": self.current_config,
-                "thread_alive": self.scheduler_thread.is_alive() if self.scheduler_thread else False,
-                "scheduler_type": self.__class__.__name__
-            }
+        # Mensuales
+        monthly = config.get("monthly", {})
+        if monthly.get("enabled"):
+            target_date = self._resolve_monthly_date(now.date(), monthly.get("day", "1"))
+            if target_date == now.date():
+                scheduled = self._build_datetime_from_time(target_date, monthly.get("time", "09:00"))
+                if self._should_run("monthly", scheduled, now, tolerance, period="month"):
+                    due_tasks.append("monthly")
 
-            if self.current_config:
-                status["is_enabled"] = self.current_config.get("enabled", False)
+        return due_tasks
 
-            if self.next_execution:
-                status["next_execution"] = self.next_execution.isoformat()
+    def _should_run(
+        self,
+        frequency: str,
+        scheduled: datetime,
+        now: datetime,
+        tolerance: timedelta,
+        period: str = "day",
+    ) -> bool:
+        """Determina si se debe ejecutar una frecuencia determinada."""
 
-            if self.last_execution_time:
-                status["last_execution"] = self.last_execution_time.isoformat()
-
-            return status
-
-        except Exception as e:
-            self._log(f"❌ Error obteniendo estado: {e}")
-            return {"error": str(e)}
-
-    def force_execution(self):
-        """
-        Fuerza la ejecución inmediata de la tarea programada (para testing).
-
-        Returns:
-            bool: True si la ejecución fue exitosa, False en caso contrario
-        """
-        self._log(f"🚀 Forzando ejecución de {self.__class__.__name__}...")
-
-        try:
-            success = self._execute_scheduled_task()
-            if success:
-                self._log(f"✅ Ejecución forzada de {self.__class__.__name__} completada exitosamente")
-            else:
-                self._log(f"❌ Ejecución forzada de {self.__class__.__name__} falló")
-            return success
-
-        except Exception as e:
-            self._log(f"💥 Error en ejecución forzada de {self.__class__.__name__}: {e}")
+        if now < scheduled:
             return False
 
-    def _log(self, message):
-        """Registra mensaje en el log de manera thread-safe."""
+        if now - scheduled > tolerance:
+            # Ya pasó demasiado tiempo, esperar a la próxima ventana
+            return False
+
+        last_run = self.last_execution_times.get(frequency)
+        if not last_run:
+            return True
+
+        if period == "day":
+            return last_run.date() != now.date()
+        if period == "week":
+            return last_run.isocalendar()[:2] != now.isocalendar()[:2]
+        if period == "month":
+            return (last_run.year, last_run.month) != (now.year, now.month)
+
+        return True
+
+    def _calculate_next_executions(
+        self, config: Dict[str, Dict], now: datetime
+    ) -> Dict[str, Optional[datetime]]:
+        """Calcula la siguiente ejecución para cada frecuencia."""
+
+        next_times: Dict[str, Optional[datetime]] = {freq: None for freq in self.FREQUENCIES}
+
+        daily = config.get("daily", {})
+        if daily.get("enabled"):
+            next_times["daily"] = self._next_daily_execution(daily, now)
+
+        weekly = config.get("weekly", {})
+        if weekly.get("enabled"):
+            next_times["weekly"] = self._next_weekly_execution(weekly, now)
+
+        monthly = config.get("monthly", {})
+        if monthly.get("enabled"):
+            next_times["monthly"] = self._next_monthly_execution(monthly, now)
+
+        return next_times
+
+    def _compute_sleep_interval(
+        self, now: datetime, next_executions: Dict[str, Optional[datetime]]
+    ) -> int:
+        """Determina cuántos segundos debe dormir el hilo."""
+
+        upcoming = [dt for dt in next_executions.values() if dt is not None]
+        if not upcoming:
+            return 60
+
+        seconds_until_next = min((dt - now).total_seconds() for dt in upcoming)
+        if seconds_until_next <= 0:
+            return 30
+
+        # Limitar a una hora para seguir revisando periódicamente
+        return int(max(30, min(seconds_until_next, 3600)))
+
+    # ------------------------------------------------------------------
+    # Helpers de cálculo de próximas ejecuciones
+    # ------------------------------------------------------------------
+    def _build_datetime_from_time(self, target_date: date, time_str: str) -> datetime:
+        hour, minute = self._split_time(time_str, default=(0, 0))
+        return datetime.combine(target_date, datetime.min.time().replace(hour=hour, minute=minute))
+
+    def _split_time(self, value: str, default: tuple[int, int]) -> tuple[int, int]:
+        try:
+            parts = value.split(":")
+            hour = int(parts[0])
+            minute = int(parts[1]) if len(parts) > 1 else 0
+        except (ValueError, AttributeError, TypeError):
+            return default
+
+        hour = max(0, min(23, hour))
+        minute = max(0, min(59, minute))
+        return hour, minute
+
+    def _next_daily_execution(self, daily: Dict, now: datetime) -> Optional[datetime]:
+        hour, minute = self._split_time(daily.get("time", "08:00"), default=(8, 0))
+        days_config = daily.get("days", {})
+
+        for offset in range(0, 7):
+            candidate_date = now.date() + timedelta(days=offset)
+            day_key = self.DAY_ORDER[(now.weekday() + offset) % 7]
+            if not days_config.get(day_key, False):
+                continue
+
+            candidate_datetime = datetime.combine(
+                candidate_date, datetime.min.time().replace(hour=hour, minute=minute)
+            )
+
+            if candidate_datetime <= now:
+                continue
+
+            return candidate_datetime
+
+        return None
+
+    def _next_weekly_execution(self, weekly: Dict, now: datetime) -> Optional[datetime]:
+        hour, minute = self._split_time(weekly.get("time", "16:00"), default=(16, 0))
+        target_day = weekly.get("day", "friday")
+        if target_day not in self.DAY_ORDER:
+            target_day = "friday"
+
+        current_weekday = now.weekday()
+        target_weekday = self.DAY_ORDER.index(target_day)
+        days_ahead = (target_weekday - current_weekday) % 7
+        if days_ahead == 0:
+            candidate_date = now.date()
+        else:
+            candidate_date = now.date() + timedelta(days=days_ahead)
+
+        candidate_datetime = datetime.combine(
+            candidate_date, datetime.min.time().replace(hour=hour, minute=minute)
+        )
+
+        if candidate_datetime <= now:
+            candidate_date += timedelta(days=7)
+            candidate_datetime = datetime.combine(
+                candidate_date, datetime.min.time().replace(hour=hour, minute=minute)
+            )
+
+        return candidate_datetime
+
+    def _next_monthly_execution(self, monthly: Dict, now: datetime) -> Optional[datetime]:
+        hour, minute = self._split_time(monthly.get("time", "09:00"), default=(9, 0))
+        day_value = monthly.get("day", "1")
+
+        candidate_date = self._resolve_monthly_date(now.date(), day_value)
+        candidate_datetime = datetime.combine(
+            candidate_date, datetime.min.time().replace(hour=hour, minute=minute)
+        )
+
+        if candidate_datetime <= now:
+            # Calcular para el mes siguiente
+            if candidate_date.month == 12:
+                next_month = 1
+                next_year = candidate_date.year + 1
+            else:
+                next_month = candidate_date.month + 1
+                next_year = candidate_date.year
+
+            next_date = date(next_year, next_month, 1)
+            candidate_date = self._resolve_monthly_date(next_date, day_value)
+            candidate_datetime = datetime.combine(
+                candidate_date, datetime.min.time().replace(hour=hour, minute=minute)
+            )
+
+        return candidate_datetime
+
+    def _resolve_monthly_date(self, reference_date: date, day_value: str) -> date:
+        """Determina la fecha correcta para un reporte mensual."""
+
+        if day_value == "last":
+            last_day = calendar.monthrange(reference_date.year, reference_date.month)[1]
+            return date(reference_date.year, reference_date.month, last_day)
+
+        try:
+            day_num = int(day_value)
+        except (ValueError, TypeError):
+            day_num = 1
+
+        last_day = calendar.monthrange(reference_date.year, reference_date.month)[1]
+        day_num = max(1, min(last_day, day_num))
+        return date(reference_date.year, reference_date.month, day_num)
+
+    # ------------------------------------------------------------------
+    # Ejecución de tareas y utilidades públicas
+    # ------------------------------------------------------------------
+    def _execute_task(self, frequency: str) -> bool:
+        """Ejecuta el callback asociado a una frecuencia."""
+
+        callback = self.callbacks.get(frequency)
+        if not callback:
+            self._log(f"⚠️ No se encontró callback para la frecuencia '{frequency}'")
+            return False
+
+        with self.lock:
+            self._log(f"⏰ Ejecutando tarea programada: {frequency}")
+            try:
+                success = bool(callback())
+            except Exception as exc:  # pragma: no cover - errores en callback
+                self._log(f"💥 Error ejecutando tarea {frequency}: {exc}")
+                success = False
+
+            if success:
+                self.last_execution_times[frequency] = datetime.now()
+                self._log(f"✅ Tarea programada '{frequency}' completada")
+            else:
+                self._log(f"❌ Tarea programada '{frequency}' finalizó con errores")
+
+            return success
+
+    def force_execution(self, frequency: Optional[str] = None) -> bool:
+        """Fuerza la ejecución inmediata de una o varias frecuencias."""
+
+        if frequency:
+            return self._execute_task(frequency)
+
+        results = [self._execute_task(freq) for freq in self.FREQUENCIES]
+        return any(results)
+
+    def get_status(self) -> Dict[str, Dict]:
+        """Retorna información del estado actual del scheduler."""
+
+        status: Dict[str, Dict] = {
+            "is_running": self.is_running,
+            "thread_alive": bool(self.thread and self.thread.is_alive()),
+            "frequencies": {},
+        }
+
+        for frequency in self.FREQUENCIES:
+            frequency_status = {
+                "enabled": self.current_config.get(frequency, {}).get("enabled", False),
+                "next_execution": self._format_datetime(self.next_executions.get(frequency)),
+                "last_execution": self._format_datetime(
+                    self.last_execution_times.get(frequency)
+                ),
+            }
+            status["frequencies"][frequency] = frequency_status
+
+        return status
+
+    def _any_frequency_enabled(self, config: Dict[str, Dict]) -> bool:
+        return any(config.get(freq, {}).get("enabled", False) for freq in self.FREQUENCIES)
+
+    def _format_datetime(self, value: Optional[datetime]) -> Optional[str]:
+        return value.isoformat() if value else None
+
+    def _log(self, message: str) -> None:
         if self.log_callback:
             try:
                 self.log_callback(message)
             except Exception:
-                # Si falla el log, no hacer nada para evitar cascada de errores
                 pass
-
-
-class DailySchedulerService(BaseSchedulerService):
-    """Servicio específico para programación de tareas diarias."""
-
-    def __init__(self, config_file, report_generator=None, log_callback=None):
-        """
-        Inicializa el servicio de programación diaria.
-
-        Args:
-            config_file (Path): Ruta al archivo de configuración
-            report_generator (callable, optional): Función para generar reportes diarios
-            log_callback (callable, optional): Función para registrar logs
-        """
-        super().__init__(config_file, log_callback)
-        self.report_generator = report_generator
-
-        # Iniciar servicio
-        self._setup_scheduler()
-
-    def _setup_scheduler(self):
-        """Configura el programador diario según los ajustes guardados."""
-        try:
-            config = self._load_config()
-            self.current_config = config
-
-            if not config:
-                self._log("Programador de reportes diarios no activado")
-                return
-
-            daily_enabled = config.get("enabled", False)
-
-            if not daily_enabled:
-                self._log("Programación de reportes diarios desactivada")
-                return
-
-            # Iniciar hilo de programación
-            self._start_scheduler_thread()
-            self._log("✅ Servicio de programación diaria iniciado correctamente")
-
-        except Exception as e:
-            self._log(f"❌ Error al configurar programador diario: {e}")
-
-    def _run_scheduler(self):
-        """Función optimizada que ejecuta el programador diario en segundo plano."""
-        self._log("📋 Bucle del programador diario iniciado")
-
-        # Valores iniciales para evitar ejecución inmediata
-        last_execution_date = datetime.now() - timedelta(days=1)
-        consecutive_errors = 0
-        max_consecutive_errors = 5
-
-        while not self.stop_event.is_set():
-            try:
-                # Cargar configuración actual (puede haber cambiado)
-                config = self._load_config()
-                self.current_config = config
-
-                if not config:
-                    # Si está deshabilitado, esperar más tiempo
-                    if self.stop_event.wait(60):  # Espera 60 segundos o hasta que se señale parada
-                        break
-                    continue
-
-                # Verificar si está habilitado
-                daily_enabled = config.get("enabled", False)
-                if not daily_enabled:
-                    if self.stop_event.wait(60):
-                        break
-                    continue
-
-                now = datetime.now()
-
-                # Comprobar reportes diarios
-                self._check_daily_execution(now, config, last_execution_date)
-
-                # Actualizar last_execution_date si se ha ejecutado
-                if self.last_execution_time and self.last_execution_time.date() == now.date():
-                    last_execution_date = self.last_execution_time
-
-                # Esperar antes de la próxima verificación (30 segundos)
-                if self.stop_event.wait(30):
-                    break
-
-            except Exception as e:
-                consecutive_errors += 1
-                self._log(f"💥 Error en el bucle del programador diario: {e}")
-
-                # Pausa más larga en caso de error
-                sleep_time = min(300, 60 * consecutive_errors)  # Máximo 5 minutos
-                if self.stop_event.wait(sleep_time):
-                    break
-
-        self._log("👋 Bucle del programador diario terminado")
-
-    def _check_daily_execution(self, now, config, last_execution_date):
-        """
-        Comprueba si es momento de ejecutar reportes diarios.
-
-        Args:
-            now (datetime): Tiempo actual
-            config (dict): Configuración actual
-            last_execution_date (datetime): Fecha de última ejecución
-        """
-        current_time = now.strftime("%H:%M")
-        scheduled_time = config.get("time", "08:00")
-
-        # Mapeo de días de la semana (0 = lunes en Python)
-        day_mapping = {
-            0: "monday", 1: "tuesday", 2: "wednesday", 3: "thursday",
-            4: "friday", 5: "saturday", 6: "sunday"
-        }
-
-        current_day = day_mapping.get(now.weekday())
-        days_config = config.get("days", {})
-
-        # Calcular próxima ejecución para logs
-        self._calculate_next_execution(config, now)
-
-        # Verificar si hoy es un día programado y si es la hora configurada
-        should_execute = (
-                days_config.get(current_day, False) and
-                current_time == scheduled_time and
-                (not self.last_execution_time or self.last_execution_time.date() != now.date())
-        )
-
-        if should_execute:
-            self._log(f"⏰ Ejecutando reporte diario programado: {current_day} {scheduled_time}")
-
-            # Ejecutar reporte de manera thread-safe
-            success = self._execute_scheduled_task()
-
-            if success:
-                self.last_execution_time = now
-                self._log("✅ Reporte diario programado ejecutado exitosamente")
-            else:
-                self._log(f"❌ Error en reporte diario programado")
-
-    def _calculate_next_execution(self, config, current_time):
-        """
-        Calcula y guarda la próxima ejecución programada diaria.
-
-        Args:
-            config (dict): Configuración actual
-            current_time (datetime): Tiempo actual
-        """
-        try:
-            days_config = config.get("days", {})
-            scheduled_time = config.get("time", "08:00")
-
-            # Encontrar el próximo día programado
-            current_weekday = current_time.weekday()
-
-            for i in range(7):  # Buscar en los próximos 7 días
-                check_day = (current_weekday + i) % 7
-                day_name = ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"][check_day]
-
-                if days_config.get(day_name, False):
-                    # Calcular fecha y hora
-                    days_ahead = i
-                    hour, minute = map(int, scheduled_time.split(":"))
-
-                    # Si es hoy pero ya pasó la hora, buscar el siguiente día programado
-                    if i == 0:
-                        scheduled_datetime = current_time.replace(hour=hour, minute=minute, second=0, microsecond=0)
-                        if scheduled_datetime <= current_time:
-                            continue  # Ya pasó la hora de hoy, buscar siguiente día
-                    else:
-                        next_date = current_time.date() + timedelta(days=days_ahead)
-                        scheduled_datetime = datetime.combine(next_date,
-                                                              datetime.min.time().replace(hour=hour, minute=minute))
-
-                    self.next_execution = scheduled_datetime
-                    break
-            else:
-                self.next_execution = None
-
-        except Exception as e:
-            self._log(f"⚠️ Error calculando próxima ejecución diaria: {e}")
-            self.next_execution = None
-
-    def _execute_scheduled_task(self):
-        """
-        Ejecuta el reporte diario programado de manera thread-safe.
-
-        Returns:
-            bool: True si la ejecución fue exitosa, False en caso contrario
-        """
-        with self.operation_lock:
-            try:
-                if self.report_generator:
-                    # Actualizar timestamp de última ejecución
-                    self.last_execution_time = datetime.now()
-
-                    # Ejecutar generador de reportes diarios
-                    result = self.report_generator()
-
-                    return bool(result)
-                else:
-                    self._log("⚠️ No se encontró función generadora de reportes diarios")
-                    return False
-
-            except Exception as e:
-                self._log(f"💥 Error al ejecutar reporte diario programado: {e}")
-                return False
-
-
-class WeeklySchedulerService(BaseSchedulerService):
-    """Servicio específico para programación de tareas semanales."""
-
-    def __init__(self, config_file, weekly_report_generator=None, log_callback=None):
-        """
-        Inicializa el servicio de programación semanal.
-
-        Args:
-            config_file (Path): Ruta al archivo de configuración
-            weekly_report_generator (callable, optional): Función para generar reportes semanales
-            log_callback (callable, optional): Función para registrar logs
-        """
-        super().__init__(config_file, log_callback)
-        self.weekly_report_generator = weekly_report_generator
-
-        # Iniciar servicio
-        self._setup_scheduler()
-
-    def _setup_scheduler(self):
-        """Configura el programador semanal según los ajustes guardados."""
-        try:
-            config = self._load_config()
-            self.current_config = config
-
-            if not config:
-                self._log("Programador de reportes semanales no activado")
-                return
-
-            # Verificar configuración específica semanal
-            weekly_config = config.get("weekly", {})
-            weekly_enabled = weekly_config.get("enabled", False)
-
-            if not weekly_enabled:
-                self._log("Programación de reportes semanales desactivada")
-                return
-
-            # Iniciar hilo de programación
-            self._start_scheduler_thread()
-            self._log("✅ Servicio de programación semanal iniciado correctamente")
-
-        except Exception as e:
-            self._log(f"❌ Error al configurar programador semanal: {e}")
-
-    def _run_scheduler(self):
-        """Función optimizada que ejecuta el programador semanal en segundo plano."""
-        self._log("📋 Bucle del programador semanal iniciado")
-
-        # Valores iniciales para evitar ejecución inmediata
-        consecutive_errors = 0
-        max_consecutive_errors = 5
-
-        while not self.stop_event.is_set():
-            try:
-                # Cargar configuración actual (puede haber cambiado)
-                config = self._load_config()
-                self.current_config = config
-
-                if not config:
-                    # Si está deshabilitado, esperar más tiempo
-                    if self.stop_event.wait(60):  # Espera 60 segundos o hasta que se señale parada
-                        break
-                    continue
-
-                # Verificar configuración específica semanal
-                weekly_config = config.get("weekly", {})
-                weekly_enabled = weekly_config.get("enabled", False)
-
-                if not weekly_enabled:
-                    if self.stop_event.wait(60):
-                        break
-                    continue
-
-                now = datetime.now()
-
-                # Comprobar reportes semanales
-                self._check_weekly_execution(now, weekly_config)
-
-                # Esperar antes de la próxima verificación (60 segundos)
-                if self.stop_event.wait(60):
-                    break
-
-            except Exception as e:
-                consecutive_errors += 1
-                self._log(f"💥 Error en el bucle del programador semanal: {e}")
-
-                # Pausa más larga en caso de error
-                sleep_time = min(300, 60 * consecutive_errors)  # Máximo 5 minutos
-                if self.stop_event.wait(sleep_time):
-                    break
-
-        self._log("👋 Bucle del programador semanal terminado")
-
-    def _check_weekly_execution(self, now, weekly_config):
-        """
-        Comprueba si es momento de ejecutar reportes semanales.
-
-        Args:
-            now (datetime): Tiempo actual
-            weekly_config (dict): Configuración semanal
-        """
-        current_time = now.strftime("%H:%M")
-        scheduled_time = weekly_config.get("time", "16:00")
-        scheduled_day = weekly_config.get("day", "friday")
-
-        # Mapeo de días de la semana (0 = lunes en Python)
-        day_mapping = {
-            0: "monday", 1: "tuesday", 2: "wednesday", 3: "thursday",
-            4: "friday", 5: "saturday", 6: "sunday"
-        }
-
-        current_day = day_mapping.get(now.weekday())
-
-        # Calcular próxima ejecución semanal para logs
-        self._calculate_next_execution(weekly_config, now)
-
-        # Verificar si hoy es el día programado y si es la hora configurada
-        # Además, verificar que no se haya ejecutado hoy todavía
-        should_execute = (
-                current_day == scheduled_day and
-                current_time == scheduled_time and
-                (not self.last_execution_time or self.last_execution_time.date() != now.date())
-        )
-
-        if should_execute:
-            self._log(f"⏰ Ejecutando reporte semanal programado: {scheduled_day} {scheduled_time}")
-
-            # Ejecutar reporte semanal de manera thread-safe
-            success = self._execute_scheduled_task()
-
-            if success:
-                self.last_execution_time = now
-                self._log("✅ Reporte semanal programado ejecutado exitosamente")
-            else:
-                self._log(f"❌ Error en reporte semanal programado")
-
-    def _calculate_next_execution(self, weekly_config, current_time):
-        """
-        Calcula y guarda la próxima ejecución programada semanal.
-
-        Args:
-            weekly_config (dict): Configuración semanal
-            current_time (datetime): Tiempo actual
-        """
-        try:
-            if not weekly_config.get("enabled", False):
-                self.next_execution = None
-                return
-
-            scheduled_day = weekly_config.get("day", "friday")
-            scheduled_time = weekly_config.get("time", "16:00")
-
-            # Mapear el día a número de día de la semana (0=lunes, 6=domingo)
-            day_mapping = {
-                "monday": 0, "tuesday": 1, "wednesday": 2, "thursday": 3,
-                "friday": 4, "saturday": 5, "sunday": 6
-            }
-
-            target_weekday = day_mapping.get(scheduled_day, 4)  # Default a viernes si no es válido
-            current_weekday = current_time.weekday()
-
-            # Calcular días hasta el próximo día programado
-            days_ahead = (target_weekday - current_weekday) % 7
-
-            # Si es el mismo día pero ya pasó la hora, sumar una semana
-            if days_ahead == 0:
-                hour, minute = map(int, scheduled_time.split(":"))
-                scheduled_datetime = current_time.replace(hour=hour, minute=minute, second=0, microsecond=0)
-                if scheduled_datetime <= current_time:
-                    days_ahead = 7  # Esperar a la próxima semana
-
-            # Calcular la fecha y hora exacta
-            next_date = current_time.date() + timedelta(days=days_ahead)
-            hour, minute = map(int, scheduled_time.split(":"))
-
-            self.next_execution = datetime.combine(
-                next_date,
-                datetime.min.time().replace(hour=hour, minute=minute)
-            )
-
-        except Exception as e:
-            self._log(f"⚠️ Error calculando próxima ejecución semanal: {e}")
-            self.next_execution = None
-
-    def _execute_scheduled_task(self):
-        """
-        Ejecuta el reporte semanal programado de manera thread-safe.
-
-        Returns:
-            bool: True si la ejecución fue exitosa, False en caso contrario
-        """
-        with self.operation_lock:
-            try:
-                if self.weekly_report_generator:
-                    # Actualizar timestamp de última ejecución
-                    self.last_execution_time = datetime.now()
-
-                    # Ejecutar generador de reportes semanales
-                    result = self.weekly_report_generator()
-
-                    return bool(result)
-                else:
-                    self._log("⚠️ No se encontró función generadora de reportes semanales")
-                    return False
-
-            except Exception as e:
-                self._log(f"💥 Error al ejecutar reporte semanal programado: {e}")
-                return False
-
-
-class MonthlySchedulerService(BaseSchedulerService):
-    """Servicio específico para programación de tareas mensuales."""
-
-    def __init__(self, config_file, monthly_report_generator=None, log_callback=None):
-        """
-        Inicializa el servicio de programación mensual.
-
-        Args:
-            config_file (Path): Ruta al archivo de configuración
-            monthly_report_generator (callable, optional): Función para generar reportes mensuales
-            log_callback (callable, optional): Función para registrar logs
-        """
-        super().__init__(config_file, log_callback)
-        self.monthly_report_generator = monthly_report_generator
-
-        # Iniciar servicio
-        self._setup_scheduler()
-
-    def _setup_scheduler(self):
-        """Configura el programador mensual según los ajustes guardados."""
-        try:
-            config = self._load_config()
-            self.current_config = config
-
-            if not config:
-                self._log("Programador de reportes mensuales no activado")
-                return
-
-            # Verificar configuración específica mensual
-            monthly_config = config.get("monthly", {})
-            monthly_enabled = monthly_config.get("enabled", False)
-
-            if not monthly_enabled:
-                self._log("Programación de reportes mensuales desactivada")
-                return
-
-            # Iniciar hilo de programación
-            self._start_scheduler_thread()
-            self._log("✅ Servicio de programación mensual iniciado correctamente")
-
-        except Exception as e:
-            self._log(f"❌ Error al configurar programador mensual: {e}")
-
-    def _run_scheduler(self):
-        """Función optimizada que ejecuta el programador mensual en segundo plano."""
-        self._log("📋 Bucle del programador mensual iniciado")
-
-        # Valores iniciales para evitar ejecución inmediata
-        consecutive_errors = 0
-        max_consecutive_errors = 5
-
-        while not self.stop_event.is_set():
-            try:
-                # Cargar configuración actual (puede haber cambiado)
-                config = self._load_config()
-                self.current_config = config
-
-                if not config:
-                    # Si está deshabilitado, esperar más tiempo
-                    if self.stop_event.wait(300):  # Espera 5 minutos o hasta que se señale parada
-                        break
-                    continue
-
-                # Verificar configuración específica mensual
-                monthly_config = config.get("monthly", {})
-                monthly_enabled = monthly_config.get("enabled", False)
-
-                if not monthly_enabled:
-                    if self.stop_event.wait(300):
-                        break
-                    continue
-
-                now = datetime.now()
-
-                # Comprobar reportes mensuales
-                self._check_monthly_execution(now, monthly_config)
-
-                # Para chequeos mensuales, una verificación cada hora es suficiente
-                if self.stop_event.wait(3600):  # 1 hora
-                    break
-
-            except Exception as e:
-                consecutive_errors += 1
-                self._log(f"💥 Error en el bucle del programador mensual: {e}")
-
-                # Pausa más larga en caso de error
-                sleep_time = min(3600, 300 * consecutive_errors)  # Máximo 1 hora
-                if self.stop_event.wait(sleep_time):
-                    break
-
-        self._log("👋 Bucle del programador mensual terminado")
-
-    def _check_monthly_execution(self, now, monthly_config):
-        """
-        Comprueba si es momento de ejecutar reportes mensuales.
-
-        Args:
-            now (datetime): Tiempo actual
-            monthly_config (dict): Configuración mensual
-        """
-        current_time = now.strftime("%H:%M")
-        scheduled_time = monthly_config.get("time", "09:00")
-        scheduled_day = monthly_config.get("day", "1")  # Día del mes (1-31 o "last")
-
-        # Determinar si hoy es el día programado
-        is_scheduled_day = False
-
-        if scheduled_day == "last":
-            # Último día del mes
-            last_day = calendar.monthrange(now.year, now.month)[1]
-            is_scheduled_day = now.day == last_day
-        else:
-            # Día específico del mes
-            try:
-                day_num = int(scheduled_day)
-                # Si el día es mayor que el último día del mes, usar el último día
-                last_day = calendar.monthrange(now.year, now.month)[1]
-                target_day = min(day_num, last_day)
-                is_scheduled_day = now.day == target_day
-            except (ValueError, TypeError):
-                self._log(f"⚠️ Configuración inválida para día del mes: {scheduled_day}")
-                is_scheduled_day = False
-
-        # Calcular próxima ejecución mensual para logs
-        self._calculate_next_execution(monthly_config, now)
-
-        # Verificar si hoy es el día programado y si es la hora configurada
-        # Además, verificar que no se haya ejecutado hoy todavía
-        should_execute = (
-                is_scheduled_day and
-                current_time == scheduled_time and
-                (not self.last_execution_time or self.last_execution_time.date() != now.date())
-        )
-
-        if should_execute:
-            day_description = "último día" if scheduled_day == "last" else f"día {scheduled_day}"
-            self._log(f"⏰ Ejecutando reporte mensual programado: {day_description} {scheduled_time}")
-
-            # Ejecutar reporte mensual de manera thread-safe
-            success = self._execute_scheduled_task()
-
-            if success:
-                self.last_execution_time = now
-                self._log("✅ Reporte mensual programado ejecutado exitosamente")
-            else:
-                self._log(f"❌ Error en reporte mensual programado")
-
-    def _calculate_next_execution(self, monthly_config, current_time):
-        """
-        Calcula y guarda la próxima ejecución programada mensual.
-
-        Args:
-            monthly_config (dict): Configuración mensual
-            current_time (datetime): Tiempo actual
-        """
-        try:
-            if not monthly_config.get("enabled", False):
-                self.next_execution = None
-                return
-
-            scheduled_day = monthly_config.get("day", "1")
-            scheduled_time = monthly_config.get("time", "09:00")
-            hour, minute = map(int, scheduled_time.split(":"))
-
-            # Determinar fecha objetivo
-            target_date = None
-            current_date = current_time.date()
-
-            # Primero comprobar si la ejecución sería hoy
-            if scheduled_day == "last":
-                # Último día del mes
-                last_day = calendar.monthrange(current_date.year, current_date.month)[1]
-                if current_date.day == last_day:
-                    # Es hoy, comprobar la hora
-                    scheduled_datetime = current_time.replace(hour=hour, minute=minute, second=0, microsecond=0)
-                    if scheduled_datetime > current_time:
-                        target_date = current_date
-            else:
-                # Día específico
-                try:
-                    day_num = int(scheduled_day)
-                    last_day = calendar.monthrange(current_date.year, current_date.month)[1]
-                    # Si el día especificado es mayor que el último día, usar el último día
-                    target_day = min(day_num, last_day)
-
-                    if current_date.day == target_day:
-                        # Es hoy, comprobar la hora
-                        scheduled_datetime = current_time.replace(hour=hour, minute=minute, second=0, microsecond=0)
-                        if scheduled_datetime > current_time:
-                            target_date = current_date
-                except (ValueError, TypeError):
-                    self._log(f"⚠️ Configuración inválida para día del mes: {scheduled_day}")
-
-            # Si no es hoy o ya pasó la hora, calcular para el próximo mes
-            if target_date is None:
-                # Determinar el mes siguiente
-                if current_date.month == 12:
-                    next_month = 1
-                    next_year = current_date.year + 1
-                else:
-                    next_month = current_date.month + 1
-                    next_year = current_date.year
-
-                if scheduled_day == "last":
-                    # Último día del próximo mes
-                    last_day = calendar.monthrange(next_year, next_month)[1]
-                    target_date = date(next_year, next_month, last_day)
-                else:
-                    # Día específico del próximo mes
-                    try:
-                        day_num = int(scheduled_day)
-                        last_day = calendar.monthrange(next_year, next_month)[1]
-                        # Si el día especificado es mayor que el último día, usar el último día
-                        target_day = min(day_num, last_day)
-                        target_date = date(next_year, next_month, target_day)
-                    except (ValueError, TypeError):
-                        # Fallback a primer día si hay error
-                        target_date = date(next_year, next_month, 1)
-
-            # Combinar fecha y hora
-            self.next_execution = datetime.combine(
-                target_date,
-                datetime.min.time().replace(hour=hour, minute=minute)
-            )
-
-        except Exception as e:
-            self._log(f"⚠️ Error calculando próxima ejecución mensual: {e}")
-            self.next_execution = None
-
-    def _execute_scheduled_task(self):
-        """
-        Ejecuta el reporte mensual programado de manera thread-safe.
-
-        Returns:
-            bool: True si la ejecución fue exitosa, False en caso contrario
-        """
-        with self.operation_lock:
-            try:
-                if self.monthly_report_generator:
-                    # Actualizar timestamp de última ejecución
-                    self.last_execution_time = datetime.now()
-
-                    # Ejecutar generador de reportes mensuales
-                    result = self.monthly_report_generator()
-
-                    return bool(result)
-                else:
-                    self._log("⚠️ No se encontró función generadora de reportes mensuales")
-                    return False
-
-            except Exception as e:
-                self._log(f"💥 Error al ejecutar reporte mensual programado: {e}")
-                return False


### PR DESCRIPTION
## Summary
- replace the individual daily, weekly and monthly schedulers with a unified background service that normalizes configuration, computes next executions and tolerates delayed wake ups
- update the scheduler modal to edit daily, weekly and monthly automation in one place, keep legacy data compatible and restart the unified scheduler on close
- adjust the top panel to expose a single scheduling button hooked to the unified service and enhance multi-criteria search detection for combined subject keywords

## Testing
- python -m compileall gui/components/scheduler_modal.py services/scheduler_service.py services/search_service.py gui/components/top_panel.py

------
https://chatgpt.com/codex/tasks/task_e_68cc84df596c832595f4d8e9483a9cff