### PR TITLE
Add sender filters to email search profiles

### DIFF
--- a/gui/components/top_panel.py
+++ b/gui/components/top_panel.py
@@ -370,8 +370,11 @@ class TopPanel:
             criterios_count = len(profile.search_criteria)
             bot_type_text = "Automático" if profile.is_bot_automatic() else "Manual"
             optimal_text = f" (óptimo: {profile.optimal_executions})" if profile.track_optimal else ""
+            sender_text = ""
+            if profile.has_sender_filters():
+                sender_text = f", remitentes: {len(profile.sender_filters)}"
             self.bottom_right_panel.add_log_entry(
-                f"Editando perfil: {profile.name} [{bot_type_text}] ({criterios_count} criterios{optimal_text})"
+                f"Editando perfil: {profile.name} [{bot_type_text}] ({criterios_count} criterios{optimal_text}{sender_text})"
             )
 
         ProfileModal(
@@ -391,11 +394,15 @@ class TopPanel:
         if profile.track_optimal:
             optimal_text = f"\nSeguimiento óptimo: {profile.optimal_executions} ejecuciones"
 
+        sender_text = ""
+        if profile.has_sender_filters():
+            sender_text = f"\nRemitentes filtrados: {', '.join(profile.sender_filters)}"
+
         confirm = messagebox.askyesno(
             "Confirmar eliminación",
             f"¿Estás seguro de eliminar el perfil '{profile.name}'?\n"
             f"Tipo de bot: {bot_type_text}\n"
-            f"Se perderán {criterios_count} {criterios_text} de búsqueda.{optimal_text}",
+            f"Se perderán {criterios_count} {criterios_text} de búsqueda.{optimal_text}{sender_text}",
             icon=messagebox.WARNING
         )
 


### PR DESCRIPTION
## Summary
- add an optional sender filter field to the profile modal so users can capture allowed senders when creating or editing search profiles
- persist sender filter metadata through `SearchProfile`/`ProfileManager`, including validation, serialization, and logging updates
- incorporate sender filters into the search service cache key and message analysis so IMAP searches only accept messages whose remitente matches (with fuzzy support)

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68cc8b3870d083258dd48935027d479f