### PR TITLE
Fix indentation in TopPanel profile deletion logging

### DIFF
--- a/gui/components/top_panel.py
+++ b/gui/components/top_panel.py
@@ -433,9 +433,9 @@ class TopPanel:
         if confirm:
             if self.profile_manager.delete_profile(profile.profile_id):
                 if self.bottom_right_panel:
-                self.bottom_right_panel.add_log_entry(
-                    f"Perfil eliminado: {profile.name} [{bot_type_text}] ({criterios_count} criterios)"
-                )
+                    self.bottom_right_panel.add_log_entry(
+                        f"Perfil eliminado: {profile.name} [{bot_type_text}] ({criterios_count} criterios)"
+                    )
                 self._load_profiles()
             else:
                 messagebox.showerror("Error", "No se pudo eliminar el perfil")


### PR DESCRIPTION
## Summary
- correct the indentation around the profile deletion log so the conditional executes properly
- keep `_load_profiles` running after deletions while logging remains optional

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d179cba65483259f9adfe0b3d3ef54