### PR TITLE
Add offline bot type support across UI and reports

### DIFF
--- a/gui/components/profile_modal.py
+++ b/gui/components/profile_modal.py
@@ -2,11 +2,26 @@
 """
 Modal para crear o editar perfiles de búsqueda.
 Permite configurar nombre, hasta 3 criterios de búsqueda diferentes,
-configuración de seguimiento de ejecuciones óptimas y tipo de bot (Automático/Manual).
+configuración de seguimiento de ejecuciones óptimas y tipo de bot (Automático/Manual/Offline).
 """
 
 import tkinter as tk
 from tkinter import ttk, messagebox
+
+from gui.models.search_profile import SearchProfile
+
+
+BOT_TYPE_DISPLAY = {
+    "automatico": "Automático",
+    "manual": "Manual",
+    "offline": "Offline"
+}
+
+BOT_TYPE_RADIO_TEXT = {
+    "automatico": "🤖 Bot Automático",
+    "manual": "👤 Bot Manual",
+    "offline": "📴 Bot Offline"
+}
 
 
 class ProfileModal:
@@ -208,31 +223,24 @@ class ProfileModal:
             font=("Arial", 11, "bold"),
             foreground="purple"
         )
-        bot_type_label.grid(row=14, column=0, columnspan=2, sticky="w", pady=(0, 10))
+        bot_type_label.grid(row=16, column=0, columnspan=2, sticky="w", pady=(0, 10))
 
         # Frame para radio buttons del tipo de bot
         bot_type_frame = ttk.Frame(main_frame)
-        bot_type_frame.grid(row=15, column=0, columnspan=2, sticky="ew", pady=(0, 15))
-        bot_type_frame.columnconfigure(0, weight=1)
-        bot_type_frame.columnconfigure(1, weight=1)
+        bot_type_frame.grid(row=17, column=0, columnspan=2, sticky="ew", pady=(0, 15))
 
-        # Radio button para Bot Automático
-        self.automatic_radio = ttk.Radiobutton(
-            bot_type_frame,
-            text="🤖 Bot Automático",
-            variable=self.bot_type,
-            value="automatico"
-        )
-        self.automatic_radio.grid(row=0, column=0, sticky="w", padx=(0, 20))
+        for idx in range(len(SearchProfile.BOT_TYPES)):
+            bot_type_frame.columnconfigure(idx, weight=1)
 
-        # Radio button para Bot Manual
-        self.manual_radio = ttk.Radiobutton(
-            bot_type_frame,
-            text="👤 Bot Manual",
-            variable=self.bot_type,
-            value="manual"
-        )
-        self.manual_radio.grid(row=0, column=1, sticky="w")
+        for idx, bot_type_value in enumerate(SearchProfile.BOT_TYPES):
+            radio = ttk.Radiobutton(
+                bot_type_frame,
+                text=BOT_TYPE_RADIO_TEXT.get(bot_type_value, bot_type_value.title()),
+                variable=self.bot_type,
+                value=bot_type_value
+            )
+            padx = (0, 20) if idx < len(SearchProfile.BOT_TYPES) - 1 else (0, 0)
+            radio.grid(row=0, column=idx, sticky="w", padx=padx)
 
         # Separador visual
         separator2 = ttk.Separator(main_frame, orient='horizontal')
@@ -314,6 +322,10 @@ class ProfileModal:
             self.optimal_entry.configure(state="disabled")
             self.optimal_executions.set("")
 
+    def _get_bot_type_display(self, bot_type):
+        """Retorna el nombre formateado del tipo de bot."""
+        return BOT_TYPE_DISPLAY.get(bot_type, "No definido")
+
     def _save_profile(self):
         """Guarda o actualiza el perfil con los múltiples criterios, seguimiento óptimo y tipo de bot."""
         name = self.profile_name.get().strip()
@@ -343,8 +355,9 @@ class ProfileModal:
             return
 
         # Validar que se haya seleccionado un tipo de bot
-        if not bot_type or bot_type not in ["automatico", "manual"]:
-            messagebox.showerror("Error", "Debe seleccionar un tipo de bot (Automático o Manual)")
+        if not bot_type or bot_type not in SearchProfile.BOT_TYPES:
+            allowed_types = ", ".join(BOT_TYPE_DISPLAY[bt] for bt in SearchProfile.BOT_TYPES)
+            messagebox.showerror("Error", f"Debe seleccionar un tipo de bot ({allowed_types})")
             return
 
         # Validar seguimiento óptimo si está habilitado
@@ -382,7 +395,7 @@ class ProfileModal:
                 )
 
                 if updated_profile:
-                    bot_type_display = "Automático" if bot_type == "automatico" else "Manual"
+                    bot_type_display = self._get_bot_type_display(bot_type)
                     mensaje = (
                         "Perfil actualizado correctamente\n\n"
                         f"Criterios configurados: {len(criterios)}\n"
@@ -407,7 +420,7 @@ class ProfileModal:
                     optimal_executions=optimal_value
                 )
                 if new_profile:
-                    bot_type_display = "Automático" if bot_type == "automatico" else "Manual"
+                    bot_type_display = self._get_bot_type_display(bot_type)
                     mensaje = (
                         "Perfil creado correctamente\n\n"
                         f"Criterios configurados: {len(criterios)}\n"

--- a/gui/models/profile_manager.py
+++ b/gui/models/profile_manager.py
@@ -185,6 +185,7 @@ class ProfileManager:
         stats = self.get_profiles_summary()
         automatic_bots = len([p for p in self.profiles if p.is_bot_automatic()])
         manual_bots = len([p for p in self.profiles if p.is_bot_manual()])
+        offline_bots = len([p for p in self.profiles if p.is_bot_offline()])
         sender_filter_profiles = len([p for p in self.profiles if p.has_sender_filters()])
         responsable_profiles = len([p for p in self.profiles if p.has_responsable()])
 
@@ -198,7 +199,9 @@ class ProfileManager:
         self._log(f"📊 Estadísticas detalladas:")
         self._log(f"  📁 Total: {stats['total_profiles']} perfiles")
         self._log(f"  🎯 Criterios: {stats['total_criteria']} total")
-        self._log(f"  🤖 Tipos: {automatic_bots} automáticos, {manual_bots} manuales")
+        self._log(
+            f"  🤖 Tipos: {automatic_bots} automáticos, {manual_bots} manuales, {offline_bots} offline"
+        )
         self._log(f"  ✉️ Filtros de remitente: {sender_filter_profiles} perfiles")
         self._log(f"  👥 Responsables definidos: {responsable_profiles}")
         self._log(f"  📈 Seguimiento: {stats['profiles_with_tracking']} con tracking óptimo")
@@ -304,7 +307,7 @@ class ProfileManager:
             search_criteria (str or list): Criterio(s) de búsqueda
             sender_filters (str or list, optional): Remitentes permitidos
             responsable (str, optional): Responsable asignado al perfil
-            bot_type (str, optional): Tipo de bot (automatico/manual)
+            bot_type (str, optional): Tipo de bot (automatico/manual/offline)
             track_optimal (bool, optional): Habilita seguimiento de ejecuciones óptimas
             optimal_executions (int, optional): Cantidad esperada de ejecuciones óptimas
 
@@ -589,6 +592,7 @@ class ProfileManager:
                 "success_rate": 0,
                 "automatic_bots": 0,
                 "manual_bots": 0,
+                "offline_bots": 0,
                 "profiles_with_sender_filter": 0,
                 "profiles_with_responsable": 0,
                 "success_categories": {}
@@ -615,6 +619,7 @@ class ProfileManager:
         # Estadísticas de tipos de bot
         automatic_bots = len([p for p in valid_profiles if p.is_bot_automatic()])
         manual_bots = len([p for p in valid_profiles if p.is_bot_manual()])
+        offline_bots = len([p for p in valid_profiles if p.is_bot_offline()])
         profiles_with_sender_filter = len([p for p in valid_profiles if p.has_sender_filters()])
         profiles_with_responsable = len([p for p in valid_profiles if p.has_responsable()])
 
@@ -638,6 +643,7 @@ class ProfileManager:
                                   1) if profiles_with_tracking else 0,
             "automatic_bots": automatic_bots,
             "manual_bots": manual_bots,
+            "offline_bots": offline_bots,
             "profiles_with_sender_filter": profiles_with_sender_filter,
             "profiles_with_responsable": profiles_with_responsable,
             "success_categories": success_categories

--- a/gui/models/search_profile.py
+++ b/gui/models/search_profile.py
@@ -2,7 +2,7 @@
 """
 Modelo optimizado para representar un perfil de búsqueda de correos.
 Contiene información sobre múltiples criterios de búsqueda (hasta 3), resultados,
-seguimiento de ejecuciones óptimas con porcentaje de éxito y tipo de bot (Automático/Manual).
+seguimiento de ejecuciones óptimas con porcentaje de éxito y tipo de bot (Automático/Manual/Offline).
 Incluye validaciones mejoradas y métodos de utilidad optimizados.
 """
 
@@ -19,7 +19,7 @@ class SearchProfile:
     MAX_CRITERIA = 3
     MIN_CRITERIA_LENGTH = 2
     MAX_CRITERIA_LENGTH = 100
-    BOT_TYPES = ["automatico", "manual"]
+    BOT_TYPES = ["automatico", "manual", "offline"]
     RESPONSABLE_MAX_LENGTH = 100
 
     def __init__(self, name, search_criteria, sender_filters=None, responsable=None, profile_id=None):
@@ -340,7 +340,7 @@ class SearchProfile:
             search_criteria (str or list): Nuevo(s) criterio(s) de búsqueda
             optimal_executions (int, optional): Cantidad de ejecuciones óptimas
             track_optimal (bool, optional): Habilitar seguimiento óptimo
-            bot_type (str, optional): Tipo de bot ("automatico" o "manual")
+            bot_type (str, optional): Tipo de bot ("automatico", "manual" u "offline")
             sender_filters (str or list, optional): Remitentes filtrados
             responsable (str, optional): Responsable del perfil
         """
@@ -545,6 +545,8 @@ class SearchProfile:
             return "🤖 Automático"
         elif self.bot_type == "manual":
             return "👤 Manual"
+        elif self.bot_type == "offline":
+            return "📴 Offline"
         else:
             return "❓ No definido"
 
@@ -565,6 +567,15 @@ class SearchProfile:
             bool: True si es manual
         """
         return self.bot_type == "manual"
+
+    def is_bot_offline(self):
+        """
+        Verifica si el bot es de tipo offline.
+
+        Returns:
+            bool: True si es offline
+        """
+        return self.bot_type == "offline"
 
     def get_age_days(self):
         """


### PR DESCRIPTION
## Summary
- add an Offline choice to the profile modal, reuse shared display labels, and tighten bot-type validation messaging
- extend search profile, manager, UI, and reporting services to recognize the new offline bot type, update statistics/logs, and include the column in Excel outputs

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68d180341838832587f5a3d81bb07cab